### PR TITLE
Fix hanging when opening a non-BackgroundBrowser.

### DIFF
--- a/bin/pithos
+++ b/bin/pithos
@@ -64,10 +64,11 @@ from pithos.pandora.data import *
 def openBrowser(url):
     print "Opening %s"%url
     webbrowser.open(url)
-    try:
-        os.wait() # workaround for http://bugs.python.org/issue5993
-    except:
-        pass
+    if isinstance(webbrowser.get(), webbrowser.BackgroundBrowser):
+        try:
+            os.wait() # workaround for http://bugs.python.org/issue5993
+        except:
+            pass
 
 def buttonMenu(button, menu):
     def cb(button):


### PR DESCRIPTION
When $BROWSER is set, its value is used instead of BackgroundBrowser('xdg-open'). This causes pithos to hang because it is waiting on a process that has already been waited on. This fixes the issue by only waiting if the browser used is a BackgroundBrowser.
