### PR TITLE
Sort stations by name

### DIFF
--- a/bin/pithos
+++ b/bin/pithos
@@ -390,11 +390,12 @@ class PithosWindow(gtk.Window):
         self.current_station = None
         selected = None
         
-        for i in self.pandora.stations:
+        def extract_name(station): return station.name
+        for i in sorted(self.pandora.stations, key=extract_name):
             if i.isQuickMix and i.isCreator:
                 self.stations_model.append((i, "QuickMix"))
         self.stations_model.append((None, 'sep'))
-        for i in self.pandora.stations:
+        for i in sorted(self.pandora.stations, key=extract_name):
             if not (i.isQuickMix and i.isCreator):
                 self.stations_model.append((i, i.name))
             if i.id == self.current_station_id:


### PR DESCRIPTION
This allows users to quickly find a single station when they have many
configured.  This affects both the main window station picker and the
manage stations dialog.
