### PR TITLE
Fix the sending of ratings to Last.fm

### DIFF
--- a/pithos/pylast.py
+++ b/pithos/pylast.py
@@ -2352,6 +2352,11 @@ class Track(_BaseObject, _Taggable):
         """Adds the track to the user's loved tracks. """
         
         self._request('track.love')
+
+    def unlove(self):
+        """Adds the track to the user's loved tracks. """
+
+        self._request('track.unlove')
     
     def ban(self):
         """Ban this track from ever playing on the radio. """


### PR DESCRIPTION
Currently, the rating of a song (loved and banned) is not sent to Last.fm: there is a send_rating function in plugins/scrobble.py but it is not hooked to any event.
