### PR TITLE
Pass empty string instead of None as the second argument to Gtk.ListStore

### DIFF
--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -667,7 +667,7 @@ class PithosWindow(Gtk.ApplicationWindow):
             song = self.current_song
         if song:
             self.songs_model[song.index][1] = self.song_text(song)
-            self.songs_model[song.index][2] = self.song_icon(song)
+            self.songs_model[song.index][2] = self.song_icon(song) or ""
         return self.playing
 
     def stations_combo_changed(self, widget):
@@ -951,4 +951,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
This is to handle backwards-incompatible changes made in Gtk 3.6 which is unavailable in Ubuntu 12.04.

Fixes https://github.com/pithos/pithos/issues/32.
