### PR TITLE
Enable clean rpm builds via setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+recursive-include data *.svg pithos.desktop

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,9 @@ except ImportError:
     ez_setup.use_setuptools()
     from setuptools import setup, find_packages
 
+# import this for the version number
+import pithos.pithosconfig
+
 import os
 
 # Utility function to read the README file.
@@ -35,7 +38,7 @@ def read(fname):
 
 setup(
     name='pithos',
-    version='0.3',
+    version=pithos.pithosconfig.VERSION,
     ext_modules=[],
     license='GPL-3',
     author='Kevin Mehall',


### PR DESCRIPTION
This lets setup.py pull the version number directly from pithosconfig.py
Adding MANIFEST.in allows setup.py sdist to pull in all the actually required files needed to a distribution tar-ball.
