### PR TITLE
Work around Debian's patched libnotify 0.7.6

### DIFF
--- a/pithos/plugins/notify.py
+++ b/pithos/plugins/notify.py
@@ -34,9 +34,17 @@ class NotifyPlugin(PithosPlugin):
             logging.warning ("libnotify not found.")
             return
 
-        if (Notify.VERSION_MAJOR, Notify.VERSION_MINOR, Notify.VERSION_MICRO) < (0, 7, 6):
-            old_add_action = Notify.Notification.add_action
-            Notify.Notification.add_action = lambda *args: old_add_action(*(args + (None,)))
+        # Pull #80
+        # Work-around Ubuntu's incompatible workaround for Gnome's API breaking
+        # mistake.
+        # https://bugzilla.gnome.org/show_bug.cgi?id=702390
+        old_add_action = Notify.Notification.add_action
+        def new_add_action(*args):
+            try:
+                old_add_action(*args)
+            except TypeError:
+                old_add_action(*(args + (None,)))
+        Notify.Notification.add_action = new_add_action
 
         Notify.init('Pithos')
         self.notification = Notify.Notification()


### PR DESCRIPTION
Don't rely on the version number. Instead, check the number of arguments
directly. Does this work?

Re: https://github.com/pithos/pithos/pull/69#issuecomment-36163317
