### PR TITLE
Buffer stop bug fix.

### DIFF
--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -463,8 +463,7 @@ class PithosWindow(Gtk.ApplicationWindow):
         self.player_status.reset()
 
         self.player.set_property("uri", self.current_song.audioUrl)
-        if self.player_status.paused:
-            self.player_status.began_buffering = time.time()
+        self.player_status.began_buffering = time.time()
         self.buffering()
         self.playcount += 1
 
@@ -522,15 +521,16 @@ class PithosWindow(Gtk.ApplicationWindow):
         self.emit('play-state-changed', False)
 
     def buffering(self):
-        self.player.set_state(Gst.State.PAUSED)
-        self.player_status.began_buffering = time.time()
-        if not self.player_status.paused:
-            self.player_status.play_state_reset()
-            self.playpause_image.set_from_icon_name('media-playback-pause-symbolic', Gtk.IconSize.SMALL_TOOLBAR)
-        self.player_status.buffering = True
-        self.player_status.stopped = False
-        self.emit('play-state-changed', True)
-        self.destroy_ui_loop()
+        if not self.player_status.buffering:
+            self.player.set_state(Gst.State.PAUSED)
+            if not self.player_status.paused:
+                self.player_status.play_state_reset()
+                self.playpause_image.set_from_icon_name('media-playback-pause-symbolic', Gtk.IconSize.SMALL_TOOLBAR)
+            self.player_status.began_buffering = time.time()
+            self.player_status.buffering = True
+            self.player_status.stopped = False
+            self.emit('play-state-changed', True)
+            self.destroy_ui_loop()
 
     def user_playpause(self, *ignore):
         self.playpause_notify()

--- a/pithos/plugins/_dbus_service.py
+++ b/pithos/plugins/_dbus_service.py
@@ -71,7 +71,7 @@ class PithosDBusProxy(dbus.service.Object):
         
     @dbus.service.method(DBUS_BUS, out_signature='b')
     def IsPlaying(self):
-        return self.window.playing
+        return self.window.player_status.playing
         
     @dbus.service.signal(DBUS_BUS, signature='b')
     def PlayStateChanged(self, state):

--- a/pithos/plugins/_mpris.py
+++ b/pithos/plugins/_mpris.py
@@ -95,7 +95,7 @@ class PithosMprisService(dbus.service.Object):
         """Current status "Playing", "Paused", or "Stopped"."""
         if not self.window.current_song:
             return "Stopped"
-        if self.window.playing:
+        if not self.window.player_status.paused:
             return "Playing"
         else:
             return "Paused"

--- a/pithos/plugins/screensaver_pause.py
+++ b/pithos/plugins/screensaver_pause.py
@@ -88,7 +88,7 @@ class ScreenSaverPausePlugin(PithosPlugin):
 
     def pause(self):
         if not self.locked:
-            self.wasplaying = self.window.playing
+            self.wasplaying = self.window.player_status.playing
             self.window.pause()
         self.locked += 1
 


### PR DESCRIPTION
1. Start pipeline in paused state.
2. Only use on_gst_buffering to start a timeout(1/10 sec) to actively query the buffer percent, and once the async-done message is received act on the buffer query accordingly.
3. Got rid of the buffer % in the buffering message as it was pretty much useless since it's only there for a fraction of a sec for mp3 streams and goes from 0 straight to 100 for aac streams.
4. Added a few switching values to make it all possible.