### PR TITLE
Don't scrobble ads.

### DIFF
--- a/pithos/plugins/lastfm.py
+++ b/pithos/plugins/lastfm.py
@@ -102,7 +102,7 @@ class LastfmPlugin(PithosPlugin):
     def scrobble(self, song):
         duration = song.get_duration_sec()
         position = song.get_position_sec()
-        if duration > 30 and (position > 240 or position > duration/2):
+        if duration > 45 and (position > 240 or position > duration/2):
             logging.info("Scrobbling song")
             mode = self.pylast.SCROBBLE_MODE_PLAYED
             source = self.pylast.SCROBBLE_SOURCE_PERSONALIZED_BROADCAST


### PR DESCRIPTION
Pithos assumes any song less than 45 sec is an ad and changes the description in the UI to reflect that. But the bogus info is still accessible. We don't want to scrobble bogus songs.