### PR TITLE
Show that a song has been scrobbled in the UI.

### DIFF
--- a/pithos/pandora/pandora.py
+++ b/pithos/pandora/pandora.py
@@ -330,6 +330,8 @@ class Song(object):
         self.songExplorerUrl = d['songExplorerUrl']
         self.artRadio = d['albumArtUrl']
 
+
+        self.scrobbled = False
         self.bitrate = None
         self.is_ad = None  # None = we haven't checked, otherwise True/False
         self.tired=False
@@ -444,4 +446,3 @@ class SearchResult(object):
             self.artist = d['artistName']
         elif resultType == 'artist':
             self.name = d['artistName']
-

--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -783,6 +783,8 @@ class PithosWindow(Gtk.ApplicationWindow):
         artist = html.escape(song.artist)
         album = html.escape(song.album)
         msg = []
+        if song.scrobbled:
+            msg.append("<small>Scrobbled to Last.fm</small>")
         if song is self.current_song:
             song.position = self.query_position()
             if not song.bitrate is None:

--- a/pithos/plugins/lastfm.py
+++ b/pithos/plugins/lastfm.py
@@ -107,6 +107,7 @@ class LastfmPlugin(PithosPlugin):
             mode = self.pylast.SCROBBLE_MODE_PLAYED
             source = self.pylast.SCROBBLE_SOURCE_PERSONALIZED_BROADCAST
             self.worker.send(self.scrobbler.scrobble, (song.artist, song.title, int(song.start_time), source, mode, duration, song.album))
+            song.scrobbled = True
 
 
 class LastFmAuth(Gtk.Dialog):
@@ -174,4 +175,3 @@ class LastFmAuth(Gtk.Dialog):
             get_worker().send(self.sg.get_web_auth_url, (), callback)
             self.button.set_label("Connecting...")
             self.button.set_sensitive(False)
-


### PR DESCRIPTION
Shows "Scrobbled to Last.fm" in the song message field after a song has been scrobbled. As it sits now the only way to know that a song has been scrobbled is running pithos -v in the terminal or going to last.fm to check.