### PR TITLE
use go-down-symbolic in station popover

### DIFF
--- a/pithos/StationsPopover.py
+++ b/pithos/StationsPopover.py
@@ -30,7 +30,7 @@ class StationsPopover(Gtk.Popover):
         self.search = Gtk.SearchEntry()
         self.sorted = False
         sort = Gtk.ToggleButton.new()
-        sort.add(Gtk.Image.new_from_icon_name("view-sort-ascending-symbolic", Gtk.IconSize.BUTTON))
+        sort.add(Gtk.Image.new_from_icon_name("go-down-symbolic", Gtk.IconSize.BUTTON))
         sort.connect("toggled", self.sort_changed)
         box2.pack_start(self.search, True, True, 0)
         box2.add(sort)


### PR DESCRIPTION
instead of view-sort-ascending-symbolic. go-down-symbolic looks nice and doesn't require GTK 3.16. As stated before kinda silly to depend on a specific version of GTK for just one icon. Especially since as of yet most popular distros don't even ship 3.16 in a stable release.