### PR TITLE
Tame the UI updates during buffering

### DIFF
--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -812,6 +812,8 @@ class PithosWindow(Gtk.ApplicationWindow):
             else:
                 logging.debug("Buffer recovery. User paused")
             self.player_status.began_buffering = None
+        if percent == 0 or percent == self.player_status.buffer_percent:
+            return
         self.player_status.buffer_percent = percent
         self.update_song_row()
 


### PR DESCRIPTION
AAC's spam the buffer messages with 0% and duplicate messages causing upwards of 1000+ buffer messages in less than 2 secs in some cases. This will calm it down a little, and make the buffer message in the UI a little more useful as it won't appear to be stuck on 0 most of the time.