### PR TITLE
Fix edge case in scrobbler function

### DIFF
--- a/pithos/plugins/lastfm.py
+++ b/pithos/plugins/lastfm.py
@@ -100,13 +100,15 @@ class LastfmPlugin(PithosPlugin):
             logging.info("Sending song rating to last.fm")
 
     def scrobble(self, song):
-        duration = song.get_duration_sec()
-        position = song.get_position_sec()
-        if not song.is_ad and duration > 30 and (position > 240 or position > duration/2):
-            logging.info("Scrobbling song")
-            mode = self.pylast.SCROBBLE_MODE_PLAYED
-            source = self.pylast.SCROBBLE_SOURCE_PERSONALIZED_BROADCAST
-            self.worker.send(self.scrobbler.scrobble, (song.artist, song.title, int(song.start_time), source, mode, duration, song.album))
+        if song.is_ad == False:
+            duration = song.get_duration_sec()
+            position = song.get_position_sec()
+            if duration is not None and position is not None:
+                if duration > 30 and (position > 240 or position > duration/2):
+                    logging.info("Scrobbling song")
+                    mode = self.pylast.SCROBBLE_MODE_PLAYED
+                    source = self.pylast.SCROBBLE_SOURCE_PERSONALIZED_BROADCAST
+                    self.worker.send(self.scrobbler.scrobble, (song.artist, song.title, int(song.start_time), source, mode, duration, song.album))
 
 
 class LastFmAuth(Gtk.Dialog):


### PR DESCRIPTION
1. We should check if song.is_ad == False because song.is_ad is a 3 way switch where None means we haven't checked yet or detection has failed, in either case we don't want to try to scrobble the track.

2. We shouldn't even try to check the duration or position if song.is_ad != False, song.is_ad == False means that the duration and position is available(duration is needed to check for ads currently). Otherwise in the edge case where a song is skipped before duration and position is available we'll get an error.