### PR TITLE
Miniature Mode

### DIFF
--- a/debug.py
+++ b/debug.py
@@ -20,7 +20,7 @@ if sys.platform != 'win32':
 
     # Enable verbose logging and test mode
     if len(sys.argv) == 1:
-        sys.argv.append('-tv')
+        sys.argv.append('-tvv')
 
 from pithos import pithos
 

--- a/pithos/data/ui/PithosWindow.ui
+++ b/pithos/data/ui/PithosWindow.ui
@@ -15,9 +15,9 @@
     <property name="default_width">500</property>
     <property name="default_height">360</property>
     <property name="icon_name">pithos</property>
+    <signal name="configure-event" handler="on_configure_event" swapped="no"/>
     <signal name="destroy" handler="on_destroy" swapped="no"/>
     <signal name="key-press-event" handler="on_kb_playpause" swapped="no"/>
-    <signal name="configure-event" handler="on_configure_event" swapped="no"/>
     <child>
       <object class="GtkBox" id="vbox1">
         <property name="visible">True</property>
@@ -37,7 +37,6 @@
                   <object class="GtkBox" id="playcontrol_box">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="homogeneous">True</property>
                     <child>
                       <object class="GtkButton" id="playpause_button">
                         <property name="visible">True</property>
@@ -55,7 +54,7 @@
                       </object>
                       <packing>
                         <property name="expand">False</property>
-                        <property name="fill">True</property>
+                        <property name="fill">False</property>
                         <property name="position">0</property>
                       </packing>
                     </child>
@@ -76,7 +75,7 @@
                       </object>
                       <packing>
                         <property name="expand">False</property>
-                        <property name="fill">True</property>
+                        <property name="fill">False</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
@@ -114,8 +113,47 @@ audio-volume-medium-symbolic</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
-                        <property name="fill">True</property>
+                        <property name="fill">False</property>
                         <property name="position">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="size">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="yalign">0.43000000715255737</property>
+                        <property name="always_show_image">True</property>
+                        <signal name="clicked" handler="user_minfull" swapped="no"/>
+                        <child>
+                          <object class="GtkImage" id="size_image">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="stock">gtk-zoom-out</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="songlabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="xalign">0.05000000074505806</property>
+                        <property name="label" translatable="yes">No Artist: No Song</property>
+                        <property name="wrap">True</property>
+                        <property name="wrap_mode">word-char</property>
+                        <property name="ellipsize">middle</property>
+                        <property name="lines">1</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">4</property>
                       </packing>
                     </child>
                   </object>
@@ -123,17 +161,6 @@ audio-volume-medium-symbolic</property>
                 <style>
                   <class name="linked"/>
                 </style>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="homogeneous">False</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkSeparatorToolItem" id="toolbutton1">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="draw">False</property>
               </object>
               <packing>
                 <property name="expand">True</property>

--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -255,6 +255,7 @@ class PithosWindow(Gtk.ApplicationWindow):
         self.mini_style_provider.load_from_data(css.encode())
 
         self.song_label = self.builder.get_object('songlabel')
+        self.song_label.hide()
 
         self.station_info = self.builder.get_object('button6')
         self.scrolled_window = self.builder.get_object('scrolledwindow1')
@@ -568,11 +569,13 @@ class PithosWindow(Gtk.ApplicationWindow):
         self.set_decorated(self.is_full)
         (w, h) = self.get_size()
         if self.is_full:
+            self.song_label.hide()
             Gtk.StyleContext.remove_provider_for_screen(
                 Gdk.Screen.get_default(),
                 self.mini_style_provider)
             self.resize(w, 350)
         else:
+            self.song_label.show()
             Gtk.StyleContext.add_provider_for_screen(
                 Gdk.Screen.get_default(),
                 self.mini_style_provider,

--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -76,8 +76,6 @@ def buttonMenu(button, menu):
 ALBUM_ART_SIZE = 96
 ALBUM_ART_X_PAD = 6
 
-BUFFER_SIZE = 192 * 1000 * 3
-
 class CellRendererAlbumArt(Gtk.CellRenderer):
     def __init__(self):
         GObject.GObject.__init__(self)

--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -195,7 +195,6 @@ class PithosWindow(Gtk.ApplicationWindow):
 
         Gst.init(None)
         self.player = Gst.ElementFactory.make("playbin", "player");
-        self.player.props.flags |= (1 << 7) # enable progressive download (GST_PLAY_FLAG_DOWNLOAD)
         bus = self.player.get_bus()
         bus.add_signal_watch()
         bus.connect("message::eos", self.on_gst_eos)

--- a/pithos/pithosconfig.py
+++ b/pithos/pithosconfig.py
@@ -19,7 +19,7 @@
 __pithos_data_directory__ = 'data/'
 __license__ = 'GPL-3'
 
-VERSION = '1.0.2'
+VERSION = '1.0.3'
 
 import os
 

--- a/pithos/pithosconfig.py
+++ b/pithos/pithosconfig.py
@@ -19,7 +19,7 @@
 __pithos_data_directory__ = 'data/'
 __license__ = 'GPL-3'
 
-VERSION = '1.0.1'
+VERSION = '1.0.2'
 
 import os
 


### PR DESCRIPTION
Hello all,

This is a "mini-mode" for Pithos, in which the window shrinks to only 32 pixels high, but still contains the vital controls (including a button to return to normal mode).  This fits my usage patterns much better than the normal UI.  I tend to have Pithos playing in the background while I work on something else. With this UI, I can stick it at the top of the screen and still have essentially maximized windows.  I suspect it would also be good for embedding in toolbars, but I haven't tested that.

I've been using it for a while now and it's been working well for me, so I thought I'd send it upstream to you.
