### PR TITLE
save sort preference in the stations popover dialog

### DIFF
--- a/pithos/PreferencesPithosDialog.py
+++ b/pithos/PreferencesPithosDialog.py
@@ -184,6 +184,7 @@ class PreferencesPithosDialog(Gtk.Dialog):
             "audio_quality": default_audio_quality,
             "pandora_one": False,
             "force_client": None,
+            "sort_stations": False
         }
 
         try:

--- a/pithos/StationsPopover.py
+++ b/pithos/StationsPopover.py
@@ -29,11 +29,11 @@ class StationsPopover(Gtk.Popover):
         box2 = Gtk.Box()
         self.search = Gtk.SearchEntry()
         self.sorted = False
-        sort = Gtk.ToggleButton.new()
-        sort.add(Gtk.Image.new_from_icon_name("view-sort-ascending-symbolic", Gtk.IconSize.BUTTON))
-        sort.connect("toggled", self.sort_changed)
+        self.sort = Gtk.ToggleButton.new()
+        self.sort.add(Gtk.Image.new_from_icon_name("view-sort-ascending-symbolic", Gtk.IconSize.BUTTON))
+        self.sort.connect("toggled", self.sort_changed)
         box2.pack_start(self.search, True, True, 0)
-        box2.add(sort)
+        box2.add(self.sort)
 
         self.listbox = Gtk.ListBox()
         self.listbox.connect('button-press-event', self.on_button_press)

--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -279,6 +279,9 @@ class PithosWindow(Gtk.ApplicationWindow):
         self.stations_popover = StationsPopover()
         self.stations_popover.set_relative_to(self.stations_button)
         self.stations_popover.set_model(self.stations_model)
+        self.stations_popover.sorted = self.preferences['sort_stations']
+        self.stations_popover.sort.connect('toggled', self.sort_toggled)
+        self.stations_popover.sort.set_active(self.stations_popover.sorted)
         self.stations_popover.listbox.connect('row-activated', self.active_station_changed)
         self.stations_button.set_popover(self.stations_popover)
         self.stations_label = self.builder.get_object('stationslabel')
@@ -895,6 +898,9 @@ class PithosWindow(Gtk.ApplicationWindow):
 
     def active_station_changed(self, listbox, row):
         self.station_changed(row.station)
+
+    def sort_toggled(self, widget):
+        self.preferences['sort_stations'] = self.stations_popover.sorted
 
     def format_time(self, time_int):
         if time_int is None:


### PR DESCRIPTION
tracked the sort button and created a 'sort_preference' setting to track the station sort preference between successive launches.

not sure if this bothers anyone else, but I prefer to always sort A-Z