### PR TITLE
Close StationsPopover on station_selected

### DIFF
--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -681,6 +681,7 @@ class PithosWindow(Gtk.ApplicationWindow):
             self.get_playlist(start = True)
         self.stations_label.set_text(station.name)
         self.stations_popover.select_station(station)
+        self.stations_popover.hide() 
 
     def query_position(self):
       pos_stat = self.player.query(self._query_position)


### PR DESCRIPTION
questionable feature, but I prefer it in my application, so I made a PR for it.

I could add this to the preferences dialog? but there's not a way to show that dialog after the first launch that I can find.