### PR TITLE
save preferences on session end (linux)

### DIFF
--- a/pithos/PreferencesPithosDialog.py
+++ b/pithos/PreferencesPithosDialog.py
@@ -177,6 +177,7 @@ class PreferencesPithosDialog(Gtk.Dialog):
             "enable_mediakeys":True,
             "enable_screensaverpause":False,
             "enable_lastfm":False,
+            "enable_save_on_logout":False,
             "enable_mpris":True,
             "volume": 1.0,
             # If set, allow insecure permissions. Implements CVE-2011-1500

--- a/pithos/plugins/save_on_logout.py
+++ b/pithos/plugins/save_on_logout.py
@@ -1,0 +1,62 @@
+### BEGIN LICENSE
+#This program is free software: you can redistribute it and/or modify it 
+#under the terms of the GNU General Public License version 3, as published 
+#by the Free Software Foundation.
+#
+#This program is distributed in the hope that it will be useful, but 
+#WITHOUT ANY WARRANTY; without even the implied warranties of 
+#MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR 
+#PURPOSE.  See the GNU General Public License for more details.
+#
+#You should have received a copy of the GNU General Public License along 
+#with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Creator: Jeremiah Cunningham <jeremiah.w.cunningham@gmail.com> 10.12.2015
+#
+### END LICENSE
+
+from pithos.plugin import PithosPlugin
+import logging
+import sys
+
+APP_ID = 'Pithos'
+
+class SaveOnLogoutPlugin(PithosPlugin):
+    preference = 'enable_save_on_logout'
+    description = 'Save preferences on Logout (linux)'
+
+    def bind_dbus(self):
+        try:
+            import dbus
+            from dbus.mainloop.glib import DBusGMainLoop
+            DBusGMainLoop(set_as_default=True)
+        except ImportError:
+            return False
+        try:
+            bus = dbus.SessionBus()
+            session_manager = bus.get_object("org.gnome.SessionManager", "/org/gnome/SessionManager")
+            self.session_manager_interface = dbus.Interface(session_manager, dbus_interface="org.gnome.SessionManager")
+            self.clientId = self.session_manager_interface.RegisterClient(APP_ID, "")
+            session_client = bus.get_object("org.gnome.SessionManager", self.clientId)
+            self.session_client_private_interface = dbus.Interface(session_client, dbus_interface="org.gnome.SessionManager.ClientPrivate")
+
+            bus.add_signal_receiver(self.end_session_handler,
+                signal_name = "EndSession",
+                dbus_interface = "org.gnome.SessionManager.ClientPrivate",
+                bus_name = "org.gnome.SessionManager")
+
+            self.method = 'dbus'
+            return True
+        except dbus.DBusException:
+            return False
+
+    def end_session_handler(self, flags):
+        self.window.prefs_dlg.save()
+        self.window.destroy()
+        self.session_client_private_interface.EndSessionResponse(True, "")
+
+    def on_enable(self):
+        if sys.platform in ['win32', 'darwin']:
+            loggin.error("Cannot use this plugin with non-linux systems currently")
+        else:
+            self.bind_dbus()


### PR DESCRIPTION
Add plugin to hook into dbus for "EndSession" signal coming from org.gnome.SessionManager. Saves preferences on logout/reboot/shutdown (proper)

will have to look into other operating systems