### PR TITLE
Create temporary local album arts files for MPRIS

### DIFF
--- a/pithos/plugins/_mpris.py
+++ b/pithos/plugins/_mpris.py
@@ -39,6 +39,7 @@ class PithosMprisService(dbus.service.Object):
         self.song_changed()
         
         self.window.connect("song-changed", self.songchange_handler)
+        self.window.connect("song-art-changed", self.artchange_handler)
         self.window.connect("song-rating-changed", self.ratingchange_handler)
         self.window.connect("play-state-changed", self.playstate_handler)
         
@@ -49,9 +50,18 @@ class PithosMprisService(dbus.service.Object):
             self.signal_paused()
         
     def songchange_handler(self, window, song):
-        self.song_changed([song.artist], song.album, song.title, song.artRadio,
+        self.song_changed([song.artist], song.album, song.title, song.artFile,
                           song.rating)
         self.signal_playing()
+
+    def artchange_handler(self, window, song):
+        if song is self.window.current_song:
+            self.__metadata['mpris:artUrl'] = song.artFile or ''
+            self.PropertiesChanged('org.mpris.MediaPlayer2.Player',
+                        dbus.Dictionary({'Metadata': self.__metadata},
+                        'sv',
+                        variant_level=1),
+                        [])
 
     def ratingchange_handler(self, window, song):
         """Handle rating changes and update MPRIS metadata accordingly"""

--- a/pithos/plugins/_mpris.py
+++ b/pithos/plugins/_mpris.py
@@ -50,13 +50,13 @@ class PithosMprisService(dbus.service.Object):
             self.signal_paused()
         
     def songchange_handler(self, window, song):
-        self.song_changed([song.artist], song.album, song.title, song.artFile,
+        self.song_changed([song.artist], song.album, song.title, song.artUrl,
                           song.rating)
         self.signal_playing()
 
     def artchange_handler(self, window, song):
         if song is self.window.current_song:
-            self.__metadata['mpris:artUrl'] = song.artFile or ''
+            self.__metadata['mpris:artUrl'] = song.artUrl or ''
             self.PropertiesChanged('org.mpris.MediaPlayer2.Player',
                         dbus.Dictionary({'Metadata': self.__metadata},
                         'sv',

--- a/pithos/plugins/_mpris.py
+++ b/pithos/plugins/_mpris.py
@@ -17,8 +17,6 @@
 
 import dbus
 import dbus.service
-import re
-import sys
 from xml.etree import ElementTree
 
 class PithosMprisService(dbus.service.Object):
@@ -50,20 +48,7 @@ class PithosMprisService(dbus.service.Object):
             self.signal_playing()
         else:
             self.signal_paused()
-
-    def get_file_url(self, filename):
-        if sys.version_info[0] == 3:
-            string_types = str,
-        else:
-            string_types = basestring,
-        if not filename or not isinstance(filename, string_types):
-            return ''
-        if re.match(r'[a-zA-Z]+://', filename):
-            return filename
-        elif re.match(r'/', filename):
-            return 'file://' + filename
-        return 'file:///' + filename
-
+        
     def songchange_handler(self, window, song):
         self.song_changed([song.artist], song.album, song.title, song.artFile,
                           song.rating)
@@ -71,7 +56,7 @@ class PithosMprisService(dbus.service.Object):
 
     def artchange_handler(self, window, song):
         if song is self.window.current_song:
-            self.__metadata['mpris:artUrl'] = self.get_file_url(song.artFile)
+            self.__metadata['mpris:artUrl'] = song.artFile or ''
             self.PropertiesChanged('org.mpris.MediaPlayer2.Player',
                         dbus.Dictionary({'Metadata': self.__metadata},
                         'sv',
@@ -92,7 +77,7 @@ class PithosMprisService(dbus.service.Object):
                                                variant_level=1),
                                [])
 
-    def song_changed(self, artists=None, album=None, title=None, artFile='',
+    def song_changed(self, artists=None, album=None, title=None, artUrl='',
                      rating=None):
         """song_changed - sets the info for the current song.
 
@@ -111,7 +96,7 @@ class PithosMprisService(dbus.service.Object):
             "xesam:title": title or "Title Unknown",
             "xesam:artist": artists or ["Artist Unknown"],
             "xesam:album": album or "Album Unknown",
-            "mpris:artUrl": self.get_file_url(artFile),
+            "mpris:artUrl": artUrl or "",
             "pithos:rating": rating or "",
         }, "sv", variant_level=1)
 


### PR DESCRIPTION
Closes #245 

The commit consists of the following changes:

pithos.py

Note, that chronologically the code works as ENTER > 1 > (5 > 2 > 4)* > 1 > EXIT

1. Creating a temporary directory, lines 237-243, and removing it on exit, lines 1120-1125.

2. get_album_art function, lines 92-114.

    a. We accept an additional parameter tmpfile, which contains the file name and handle for the temporary file.
    b. We try to right the original image (before resizing) to the file. At first, I thought we could have done this in art_callback, but there we would have only the image 96x96, not the original 500x500.
    c. We return an additional parameter after pixbuf, which is the file name or None, depending on whether writing to the file was successful.

3. A new signal "song-art-changed", line 133, is needed to let MPRIS know when the arts for the current song was downloaded if it started playing a song before that (for example, the first song).

4. Function art_callback, lines 603-612. As was mentioned above, an additional parameter is now returned to the art_callback, so if it is not None, there is a file with the arts, and we reassign song.artFile and issue the signal, so MPRIS will know.

5. Function callback, changed lines 622-629. This function is called when the playlist is created or updated. For each new song (variable i) we first set i.artFile=None and try to create a temporary file to store the image. If the file is created successfully, as was mentioned above, we pass it to get_album_art, and if it successfully writes the image to the file, it will return the file name to art_callback, which will update song.artFile and issue the signal. Before all this happens, i.artFile should be None, as there is no file yet, should MPRIS already start playing this song.

_mpris.py

1. Line 42, connect to the new signal to know when the album arts are downloaded.

2. Line 53, use artFile instead of artUrl for the local image.

3. Lines 57-65, update the album arts link, only if it was changed for the currently playing song.

Additional comments:

- Without the new signal and signal handling, the album arts is not shown for the first song, and when one quickly switches from the 3rd song to the 5th, or from the 7th to the 9th etc. (when a new portion of the list is still being downloaded). And if we pass the name of the future file right away, it won't be updated in the sound menu even when the file is downloaded, so we need to pass None at first, and then update it using the signal.

- At first, I thought to delete the temporary image files as soon as a song finishes, but it leads to unnecessary complications. Anyway, the files are small, so even if you listen to hundred songs, the arts won't take more than several megabytes. So, we can delete them all at once in the end.