### PR TITLE
Make use of the stream-start gstreamer message and clean up unneeded ones.

### DIFF
--- a/pithos/pandora/pandora.py
+++ b/pithos/pandora/pandora.py
@@ -393,7 +393,6 @@ class Song:
                     'audioUrl': d['additionalAudioUrl'][0],
                 }
 
-        self.bitrate = None
         self.is_ad = None  # None = we haven't checked, otherwise True/False
         self.tired=False
         self.message=''
@@ -433,11 +432,13 @@ class Song:
         quality = self.pandora.audio_quality
         try:
             q = self.audioUrlMap[quality]
+            self.bitrate = q['bitrate']
             logging.info("Using audio quality %s: %s %s", quality, q['bitrate'], q['encoding'])
             return q['audioUrl']
         except KeyError:
             logging.warning("Unable to use audio format %s. Using %s",
                            quality, list(self.audioUrlMap.keys())[0])
+            self.bitrate = list(self.audioUrlMap.values())[0]['bitrate']
             return list(self.audioUrlMap.values())[0]['audioUrl']
 
     @property


### PR DESCRIPTION
The songs duration can be got at and we can check for ads at the posting of the stream-start message. This allows us to remove async-done and duration-change. We can also git rid of the tag message(that spams the heck out of debug mode). The only thing we use it for is getting the bitrate which Pandora already gives us.