### PR TITLE
MPRIS Fixup

### DIFF
--- a/pithos/plugins/_mpris.py
+++ b/pithos/plugins/_mpris.py
@@ -147,8 +147,9 @@ class PithosMprisService(DBusServiceObject):
     def _duration(self):
         # use the duration provided by Pandora
         # if Gstreamer hasn't figured out the duration yet
-        if self.window.query_duration() is not None:
-            return self.window.query_duration() // 1000
+        gst_duration = self.window.query_duration()
+        if gst_duration is not None:
+            return gst_duration // 1000
         else:
             return self.window.current_song.trackLength * 1000000
 


### PR DESCRIPTION
Fixes: TypeError: unsupported operand type(s) for //: 'NoneType' and 'int'

For some reason self.window.query_duration() passes the None check and then shortly after returns None. This should fix that by caching the 1st call and reusing the value instead of calling it twice.