### PR TITLE
Return a generator from get_playlist instead of a list

### DIFF
--- a/pithos/pandora/pandora.py
+++ b/pithos/pandora/pandora.py
@@ -328,12 +328,8 @@ class Station:
                         'stationToken': self.idToken,
                         'includeTrackLength': True,
                         'additionalAudioUrl': 'HTTP_32_AACPLUS,HTTP_128_MP3',
-                    }, https=True)
-        songs = []
-        for i in playlist['items']:
-            if 'songName' in i: # check for ads
-                songs.append(Song(self.pandora, i))
-        return songs
+                    }, https=True)['items']
+        return (Song(self.pandora, i) for i in playlist if 'songName' in i)
 
     @property
     def info_url(self):


### PR DESCRIPTION
get_playlist may as well return a generator because:
1. It's only iterated over once.
2. We don't use any list feature with it.
3. Generators are faster than lists.(probably a microscopic difference in this case)