### PR TITLE
Rewrite of notify.py

### DIFF
--- a/pithos/plugins/notify.py
+++ b/pithos/plugins/notify.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8; tab-width: 4; indent-tabs-mode: nil; -*-
-### BEGIN LICENSE
-# Copyright (C) 2010-2012 Kevin Mehall <km@kevinmehall.net>
+#
+# Copyright (C) 2016 Jason Gray <jasonlevigray3@gmail.com>
+#
 #This program is free software: you can redistribute it and/or modify it 
 #under the terms of the GNU General Public License version 3, as published 
 #by the Free Software Foundation.
@@ -16,142 +16,135 @@
 
 import logging
 import html
-from sys import platform
+from gettext import gettext as _
 from pithos.plugin import PithosPlugin
-
 import gi
-gi.require_version('Notify', '0.7')
-from gi.repository import (GLib, Gtk)
+from gi.repository import GLib, Gio, Gtk
 
 class NotifyPlugin(PithosPlugin):
     preference = 'notify'
     description = 'Shows notifications on song change'
 
-    has_notifications = False
-    supports_actions = False
-    escape_markup = False
-
     def on_prepare(self):
-        if platform == 'darwin':
-            return self.prepare_osx()
-        else:
-            return self.prepare_notify()
-
-    def prepare_osx(self):
-        try:
-            from pync import Notifier
-            self.has_notifications = True
-        except ImportError:
-            logging.warning("pync not found.")
-            return "pync not found"
-
-        self.notifier = Notifier
-
-    def prepare_notify(self):
-        try:
-            from gi.repository import Notify
-            self.has_notifications = True
-        except ImportError:
-            logging.warning ("libnotify not found.")
-            return "libnotify not found"
-
-        # Work-around Ubuntu's incompatible workaround for Gnome's API breaking mistake.
-        # https://bugzilla.gnome.org/show_bug.cgi?id=702390
-        old_add_action = Notify.Notification.add_action
-        def new_add_action(*args):
-            try:
-                old_add_action(*args)
-            except TypeError:
-                old_add_action(*(args + (None,)))
-        Notify.Notification.add_action = new_add_action
-
-        Notify.init('pithos')
-        self.notification = Notify.Notification()
-        self.notification.set_category('x-gnome.music')
-        self.notification.set_hint('desktop-entry', GLib.Variant.new_string('pithos'))
-
-        caps = Notify.get_server_caps()
-        if 'actions' in caps:
-            logging.info('Notify supports actions')
-            self.supports_actions = True
-
-        if 'body-markup' in caps:
-            self.escape_markup = True
-
-        if 'action-icons' in caps:
-            self.notification.set_hint('action-icons', GLib.Variant.new_boolean(True))
-
-        # TODO: On gnome this can replace the tray icon, just need to add love/hate buttons
-        #if 'persistence' in caps:
-        #    self.notification.set_hint('resident', GLib.Variant.new_boolean(True))
+        pass
 
     def on_enable(self):
-        if self.has_notifications:
-            self.song_callback_handle = self.window.connect("song-changed", self.song_changed)
-            self.state_changed_handle = self.window.connect("user-changed-play-state", self.playstate_changed)
+        def on_DBusConnection_finish(cancelable, result):
+            DBusConnection = Gio.bus_get_finish(result)
+            Gio.DBusProxy.new(DBusConnection,
+                              Gio.DBusCallFlags.NONE,
+                              None,
+                              'org.freedesktop.Notifications',
+                              '/org/freedesktop/Notifications',
+                              'org.freedesktop.Notifications',
+                              None,
+                              on_DBusProxy_finish,
+            )
 
-    def set_actions(self, playing=True):
-        self.notification.clear_actions()
+        def on_DBusProxy_finish(DBusProxy, result):
+            self.NotificationsDBusProxy = DBusProxy.new_finish(result)
+            self.NotificationsDBusProxy.call('GetCapabilities', None, Gio.DBusCallFlags.NONE, -1, None, on_GetCapabilities_finish)
 
-        pause_action = 'media-playback-pause'
-        play_action = 'media-playback-start'
-        skip_action = 'media-skip-forward'
+        def on_GetCapabilities_finish(NotificationsDBusProxy, result):
+            Capabilities = NotificationsDBusProxy.call_finish(result).unpack()[0]
+            self.supports_actions = False
+            self.escape_markup = False
+            self.NotificationId = 0
+            self.play_pause_identifier = ''
+            self.skip_identifier = ''
+            self.g_signal_handler = None
+            self.actions = []
+            self.hints = {'category': GLib.Variant.new_string('x-gnome.music'),
+                          'desktop-entry': GLib.Variant.new_string('io.github.Pithos'),
+            }
 
-        if Gtk.Widget.get_default_direction() == Gtk.TextDirection.RTL:
-            play_action += '-rtl'
-            skip_action += '-rtl'
+            if 'persistence' in Capabilities:
+                logging.debug('Notification server supports persistence')
 
-        if playing:
-            self.notification.add_action(pause_action, 'Pause',
-                                         self.notification_playpause_cb, None)
-        else:
-            self.notification.add_action(play_action, 'Play',
-                                         self.notification_playpause_cb, None)
+            if 'actions' in Capabilities:
+                self.supports_actions = True
+                self.g_signal_handler = self.NotificationsDBusProxy.connect('g-signal', self.on_g_signal)
+                logging.debug('Notification server supports actions')
 
-        self.notification.add_action(skip_action, 'Skip',
-                                     self.notification_skip_cb, None)
+            if 'action-icons' in Capabilities:
+                self.hints['action-icons'] = GLib.Variant.new_boolean(True)
+                logging.debug('Notification server supports action icons')
 
-    def set_notification_notify(self, song, playing):
+            if 'body-markup' in Capabilities:
+                self.escape_markup = True
+                logging.debug('Notification server supports body markup')             
+
+            self.song_change_handler = self.window.connect('song-changed', self.on_song_changed)
+            self.state_change_handler = self.window.connect('user-changed-play-state', self.on_playstate_changed)
+
+        Gio.bus_get(Gio.BusType.SESSION, None, on_DBusConnection_finish)
+
+    def on_g_signal(self, proxy, sender_name, signal_name, parameters):
+        id, action_key = parameters
+        if id != self.NotificationId:
+            return
+        if signal_name == 'ActionInvoked':
+            if action_key == self.play_pause_identifier:
+                self.window.playpause_notify()
+            elif action_key == self.skip_identifier:
+                self.window.next_song()
+            logging.debug('Notification Action Invoked: %s', action_key)
+
+    def on_playstate_changed(self, window, playing):
+        if self.window.is_active():
+            return
+        self.send_notification(window.current_song, playing)
+
+    def on_song_changed(self, window, song):
+        if self.window.is_active():
+            return
+        self.send_notification(song)
+
+    def send_notification(self, song, playing=True):
+        def on_NotificationsDBusProxy_call_finish(NotificationsDBusProxy, result):
+            self.NotificationId = NotificationsDBusProxy.call_finish(result).unpack()[0]
+
         if self.supports_actions:
             self.set_actions(playing)
 
-        msg = 'by {} from {}'.format(song.artist, song.album)
+        summary = song.title
+        body = '{} {} {} {}'.format(_('by'), song.artist, _('from'), song.album)
         if self.escape_markup:
-            msg = html.escape(msg, quote=False)
-        if song.art_pixbuf:
-            self.notification.set_image_from_pixbuf(song.art_pixbuf)
-            self.notification.update(song.title, msg)
+            body = html.escape(body, quote=False)
+        if song.artUrl:
+            icon = song.artUrl
         else:
-            self.notification.update(song.title, msg, 'audio-x-generic')
-        self.notification.show()
+            icon = 'audio-x-generic'
 
-    def set_notification_osx(self, song, playing):
-        # TODO: Icons (buttons not possible?)
+        args = GLib.Variant('(susssasa{sv}i)', ('Pithos', self.NotificationId, icon, summary, body,
+                                                self.actions, self.hints, -1))
+
+        self.NotificationsDBusProxy.call('Notify', args, Gio.DBusCallFlags.NONE, -1, None, on_NotificationsDBusProxy_call_finish)
+
+    def set_actions(self, playing):
+        pause_identifier = 'media-playback-pause'
+        play_identifier = 'media-playback-start'
+        self.skip_identifier = 'media-skip-forward'
+
+        if Gtk.Widget.get_default_direction() == Gtk.TextDirection.RTL:
+            play_identifier += '-rtl'
+            self.skip_identifier += '-rtl'
+
         if playing:
-            self.notifier.notify('by {} from {}'.format(song.artist, song.album),
-                                title=song.title)
-
-    def set_notification(self, song, playing=True):
-        if platform == 'darwin':
-            self.set_notification_osx(song, playing)
+            self.play_pause_identifier = pause_identifier
+            play_pause_display_str = 'Pause'
         else:
-            self.set_notification_notify(song, playing)
+            self.play_pause_identifier = play_identifier
+            play_pause_display_str = 'Play'
 
-    def notification_playpause_cb(self, notification, action, data, ignore=None):
-        self.window.playpause_notify()
-
-    def notification_skip_cb(self, notification, action, data, ignore=None):
-        self.window.next_song()
-
-    def song_changed(self, window,  song):
-        if not self.window.is_active():
-            GLib.idle_add(self.set_notification, window.current_song)
-
-    def playstate_changed(self, window, state):
-        if not self.window.is_active():
-            GLib.idle_add(self.set_notification, window.current_song, state)
+        self.actions = [self.play_pause_identifier,
+                        _(play_pause_display_str),
+                        self.skip_identifier,
+                        _('Skip'),
+        ]
 
     def on_disable(self):
-        if self.has_notifications:
-            self.window.disconnect(self.song_callback_handle)
-            self.window.disconnect(self.state_changed_handle)
+        self.window.disconnect(self.song_change_handler)
+        self.window.disconnect(self.state_change_handler)
+        if self.g_signal_handler is not None:
+            self.NotificationsDBusProxy.disconnect(self.g_signal_handler)


### PR DESCRIPTION
1. Complete rewrite from scratch using Gio.DBusProxy.
2. Removed external (crufty) libnotify dependency.
3. Completely, 100% non-blocking/asynchronous method calls, including initialization.
4. Removed unused OSX support.(haven't been able to install Pithos in OSX in a while now.)
5. Made Notifications translatable where appropriate.
