### PR TITLE
mpris: Send empty return value for DBUS methods.

### DIFF
--- a/pithos/plugins/dbus_util/DBusServiceObject.py
+++ b/pithos/plugins/dbus_util/DBusServiceObject.py
@@ -325,8 +325,9 @@ class DBusServiceObject(GObject.Object):
         try:
             ret = method(*parameters.unpack())
             if ret is None and not info.out_args:
-                return # No return value
-            invocation.return_value(GLib.Variant('(%s)' %info.out_args[0].signature, (ret,)))
+                invocation.return_value(None)
+            else:
+                invocation.return_value(GLib.Variant('(%s)' %info.out_args[0].signature, (ret,)))
         except Exception as e:
             invocation.return_error_literal(Gio.dbus_error_quark(),
                     Gio.DBusError.IO_ERROR,


### PR DESCRIPTION
I was writing a simple MPRIS client, and I noticed that it would hang any time I tried to call a method for Pithos, even though Pithos itself seemed to respond fine.

As far as I understand, if a DBus method doesn't return anything, then it's still required to send an empty return value (or an error) as a reply. Since Pithos doesn't send that reply, the client hangs waiting for one.

So, this change just adds a call to `g_dbus_method_invocation_return_value` with an empty parameter list when the method doesn't have anything to return.