### PR TITLE
Add an "end-of-stream" signal

### DIFF
--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -105,6 +105,7 @@ class PithosWindow(Gtk.ApplicationWindow):
         "user-changed-play-state": (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_BOOLEAN,)),
         "metadata-changed": (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
         "buffering-finished": (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
+        "end-of-stream": (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
     }
 
     volume = GtkTemplate.Child()
@@ -769,6 +770,7 @@ class PithosWindow(Gtk.ApplicationWindow):
 
     def on_gst_eos(self, bus, message):
         logging.info("EOS")
+        self.emit('end-of-stream', self.current_song)
         self.next_song()
 
     def on_gst_plugin_installed(self, result, userdata):


### PR DESCRIPTION
Emit the "end-of-stream" signal when the "eos" message is received
from the gstreamer bus.  This change will allow plugins to perform
synchronous actions when this message is received.