### PR TITLE
Remove redundant user-changed-play-state signal

### DIFF
--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -102,7 +102,6 @@ class PithosWindow(Gtk.ApplicationWindow):
         "song-changed": (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
         "song-ended": (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
         "play-state-changed": (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_BOOLEAN,)),
-        "user-changed-play-state": (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_BOOLEAN,)),
         "metadata-changed": (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
         "buffering-finished": (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
     }
@@ -573,7 +572,6 @@ class PithosWindow(Gtk.ApplicationWindow):
 
     def user_play(self, *ignore):
         self.play()
-        self.emit('user-changed-play-state', True)
 
     def play(self):
         if not self.playing:
@@ -586,7 +584,6 @@ class PithosWindow(Gtk.ApplicationWindow):
 
     def user_pause(self, *ignore):
         self.pause()
-        self.emit('user-changed-play-state', False)
 
     def pause(self):
         self.playing = False

--- a/pithos/plugins/notify.py
+++ b/pithos/plugins/notify.py
@@ -88,7 +88,7 @@ class NotifyPlugin(PithosPlugin):
     def on_enable(self):
         if self.has_notifications:
             self.song_callback_handle = self.window.connect("song-changed", self.song_changed)
-            self.state_changed_handle = self.window.connect("user-changed-play-state", self.playstate_changed)
+            self.state_changed_handle = self.window.connect("play-state-changed", self.playstate_changed)
 
     def set_actions(self, playing=True):
         self.notification.clear_actions()


### PR DESCRIPTION
user-changed-play-state is redundant because it is always followed by the play-state-changed which serves the same purpose.