### PR TITLE
Check the validity of a song when going from pause to play.

### DIFF
--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -544,7 +544,7 @@ class PithosWindow(Gtk.ApplicationWindow):
             self.update_song_row(prev)
 
         if not self.current_song.is_still_valid():
-            self.current_song.message = "Playlist expired"
+            self.current_song.message = 'Song expired'
             self.update_song_row()
             return self.next_song()
 
@@ -576,6 +576,11 @@ class PithosWindow(Gtk.ApplicationWindow):
         self.emit('user-changed-play-state', True)
 
     def play(self):
+        if not self.current_song.is_still_valid():
+            self.current_song.message = 'Song expired'
+            self.update_song_row()
+            return self.next_song()
+ 
         if not self.playing:
             self.playing = True
             self.create_ui_loop()


### PR DESCRIPTION
Check the validity of a song when going from pause to play to more gracefully indicate that a song is no longer valid if it has become invalid while it was paused. Mostly useful in conjunction with the screensaver pause plugin or after other long periods in which Pithos might be left in a paused state. So when the user unlocked the screen Pithos would skip to a valid song without throwing a bunch of Gstreamer errors.
