### PR TITLE
Stops Pithos from quitting when loggin and Pandora One is changed

### DIFF
--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -437,7 +437,7 @@ class PithosWindow(Gtk.ApplicationWindow):
 
 
         email = self.settings['email']
-        password = get_account_password(email)
+        password = get_account_password(email) or self.prefs_dlg.password_entry.get_text()
         if not email or not password:
             # You probably shouldn't be able to reach here
             # with no credentials set


### PR DESCRIPTION
A bit of an edge case but I have 2 accounts one account is my main listening account, it is a Pandora Plus(or One) account the other is a free account. They both have the same password. If I change both the Pandora One checkbox and the loggin without changing the password Pithos quits with a "No email or no password set!" error. This stops that from happening and Pithos behaves as expected and logs into the other account.