### PR TITLE
Move Pulseaudio props to application.py

### DIFF
--- a/pithos/application.py
+++ b/pithos/application.py
@@ -12,7 +12,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
+import os
 import sys
 import signal
 import logging
@@ -31,6 +31,12 @@ class PithosApplication(Gtk.Application):
     def __init__(self, version=''):
         super().__init__(application_id='io.github.Pithos',
                          flags=Gio.ApplicationFlags.HANDLES_COMMAND_LINE)
+
+        os.environ['PULSE_PROP_application.name'] = 'Pithos'
+        os.environ['PULSE_PROP_application.version'] = version
+        os.environ['PULSE_PROP_application.icon_name'] = 'io.github.Pithos'
+        os.environ['PULSE_PROP_media.role'] = 'music'
+
         self.window = None
         self.test_mode = False
         self.version = version

--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -18,7 +18,6 @@ import html
 import json
 import logging
 import math
-import os
 import re
 import sys
 import time
@@ -218,7 +217,6 @@ class PithosWindow(Gtk.ApplicationWindow):
     def init_ui(self):
         GLib.set_application_name("Pithos")
         Gtk.Window.set_default_icon_name('pithos')
-        os.environ['PULSE_PROP_media.role'] = 'music'
 
         self.volume.set_relief(Gtk.ReliefStyle.NORMAL)  # It ignores glade...
         self.settings.bind('volume', self.volume, 'value', Gio.SettingsBindFlags.DEFAULT)


### PR DESCRIPTION
And set the name, version and icon_name props. The icon_name prop is needed so that a Pithos icon is shown in the GNOME sound settings.