### PR TITLE
Silence Gtk-WARNING **: Allocating size...

### DIFF
--- a/data/ui/SearchDialog.ui
+++ b/data/ui/SearchDialog.ui
@@ -5,6 +5,7 @@
   <template class="SearchDialog" parent="GtkDialog">
     <property name="width_request">380</property>
     <property name="height_request">350</property>
+    <property name="resizable">0</property>
     <property name="border_width">2</property>
     <property name="modal">1</property>
     <property name="title" translatable="yes">Search</property>


### PR DESCRIPTION
Gtk spams us with:

Gtk-WARNING **: Allocating size to SearchDialog ... without calling gtk_widget_get_preferred_width/height(). How does the code know the size to allocate?

Every time we get search results. This will shut Gtk up by making the dialog non-resizable.