### PR TITLE
fix not reconnecting on PandoraAuthTokenInvalid error.

### DIFF
--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -350,7 +350,7 @@ class PithosWindow(Gtk.ApplicationWindow):
             if isinstance(e, PandoraAuthTokenInvalid) and not self.auto_retrying_auth:
                 self.auto_retrying_auth = True
                 logging.info("Automatic reconnect after invalid auth token")
-                self.pandora_connect("Reconnecting...", retry_cb)
+                self.pandora_connect(message="Reconnecting...", callback=retry_cb)
             elif isinstance(e, PandoraAPIVersionError):
                 self.api_update_dialog()
             elif isinstance(e, PandoraError):


### PR DESCRIPTION
https://github.com/pithos/pithos/commit/bdf52ae5a1133373ded8c02012f4e9ffa0c35339 added an *ignore to pandora_connect that swallowed up the args. This fixes that by converting them to kwargs.