### PR TITLE
transient song notifications for GNOME Shell 3.20+

### DIFF
--- a/pithos/plugins/notify.py
+++ b/pithos/plugins/notify.py
@@ -45,6 +45,18 @@ class NotifyPlugin(PithosPlugin):
         if 'action-icons' in caps:
             self.notification.set_hint('action-icons', GLib.Variant('b', True))
 
+        # GNOME Shell 3.20 or higher has bultin MPRIS functionality that makes
+        # persistent song notifications redundant.
+        has_built_in_mpris = False
+        version = server_info['version'].split('.')
+        if server_info['name'] == 'gnome-shell' and len(version) >= 2:
+            major_version, minor_version = (int(x) if x.isdigit() else 0 for x in version[0:2])
+            if major_version == 3 and minor_version >= 20:
+                has_built_in_mpris = True
+
+        if 'persistence' in caps and has_built_in_mpris:
+            self.notification.set_hint('transient', GLib.Variant('b', True))
+
         server_info = '\n'.join(('{}: {}'.format(k, v) for k, v in server_info.items()))
         logging.debug('\nNotification Server Information:\n{}'.format(server_info))
 


### PR DESCRIPTION
GNOME Shell 3.20 or higher has bultin MPRIS functionality that makes persistent song notifications redundant.