### PR TITLE
Make journald logging a plugin

### DIFF
--- a/data/io.github.Pithos.gschema.xml
+++ b/data/io.github.Pithos.gschema.xml
@@ -66,6 +66,7 @@
     <child name="mediakeys" schema="io.github.Pithos.plugin-enabled"/>
     <child name="screensaver-pause" schema="io.github.Pithos.plugin-enabled"/>
     <child name="mpris" schema="io.github.Pithos.plugin-enabled"/>
+    <child name="journald-logging" schema="io.github.Pithos.plugin-enabled"/>
     <child name="notify" schema="io.github.Pithos.plugin"/>
     <child name="lastfm" schema="io.github.Pithos.plugin"/>
     <child name="notification-icon" schema="io.github.Pithos.plugin"/>

--- a/pithos/PreferencesPithosDialog.py
+++ b/pithos/PreferencesPithosDialog.py
@@ -50,12 +50,23 @@ class PithosPluginRow(Gtk.ListBoxRow):
         self.switch.connect('notify::active', self.on_activated)
         self.switch.set_valign(Gtk.Align.CENTER)
         box.pack_end(self.switch, False, False, 2)
+        self.connect('grab-focus', self.on_grab_focus)
 
         if plugin.prepared and plugin.error:
             self.set_sensitive(False)
             self.set_tooltip_text(plugin.error)
 
         self.add(box)
+
+    def set_prefs_btn(self):
+        if self.plugin.enabled:
+            sensitive = self.plugin.preferences_dialog is not None
+        else:
+            sensitive = False
+        self.get_toplevel().preference_btn.set_sensitive(sensitive)
+
+    def on_grab_focus(self, *ignore):
+        self.set_prefs_btn()
 
     def on_activated(self, obj, params):
         if not self.is_selected():
@@ -71,7 +82,7 @@ class PithosPluginRow(Gtk.ListBoxRow):
             self.set_sensitive(False)
             self.set_tooltip_text(self.plugin.error)
         elif self.plugin.prepared:
-            self.get_toplevel().preference_btn.set_sensitive(self.plugin.preferences_dialog is not None)
+            self.set_prefs_btn()
 
 
 @GtkTemplate(ui='/io/github/Pithos/ui/PreferencesPithosDialog.ui')

--- a/pithos/plugins/journald_logging.py
+++ b/pithos/plugins/journald_logging.py
@@ -1,0 +1,146 @@
+#
+# Copyright (C) 2016 Jason Gray <jasonlevigray3@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3, as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranties of
+# MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+# END LICENSE
+
+import logging
+
+from gi.repository import GObject, Gtk
+
+from pithos.plugin import PithosPlugin
+
+LOG_LEVELS = {
+    'debug': logging.DEBUG,
+    'verbose': logging.INFO,
+    'warning': logging.WARN,
+}
+
+
+class JournalLoggingPlugin(PithosPlugin):
+    preference = 'journald-logging'
+    description = _('Store logs with the journald service')
+
+    _logging_changed_handler = None
+
+    def on_prepare(self):
+        try:
+            from systemd.journal import JournalHandler
+            self._journal = JournalHandler(SYSLOG_IDENTIFIER='io.github.Pithos')
+            self._journal.setFormatter(logging.Formatter())
+            self._logger = logging.getLogger()
+            self.preferences_dialog = LoggingPluginPrefsDialog(self.window, self.settings)
+        except ImportError:
+            return _('Systemd Python module not found')
+
+    def on_enable(self):
+        self._on_logging_changed(None, self.settings['data'] or 'verbose')
+        self._logger.addHandler(self._journal)
+        self._logging_changed_handler = self.preferences_dialog.connect('logging-changed', self._on_logging_changed)
+
+    def _on_logging_changed(self, prefs_dialog, level):
+        self.settings['data'] = level
+        self._journal.setLevel(LOG_LEVELS[level])
+        logging.info('setting journald logging level to: {}'.format(level))
+
+    def on_disable(self):
+        if self._logging_changed_handler:
+            self.preferences_dialog.disconnect(self._logging_changed_handler)
+        self._logger.removeHandler(self._journal)
+
+
+class LoggingPluginPrefsDialog(Gtk.Dialog):
+    __gtype_name__ = 'LoggingPluginPrefsDialog'
+    __gsignals__ = {
+        'logging-changed': (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_STRING,)),
+    }
+
+    def __init__(self, parent, settings, *args, **kwargs):
+        super().__init__(
+            _('Logging Level'),
+            parent,
+            0,
+            ('_Cancel', Gtk.ResponseType.CANCEL, '_Apply', Gtk.ResponseType.APPLY),
+            *args,
+            use_header_bar=1,
+            **kwargs,
+        )
+        self.pithos_window = parent
+        self.settings = settings
+        self.set_resizable(False)
+        self.connect('response', self._on_response)
+
+        sub_title = Gtk.Label.new(_('Set the journald logging level for Pithos'))
+        sub_title.set_halign(Gtk.Align.CENTER)
+        self.log_level_combo = Gtk.ComboBoxText.new()
+
+        logging_levels = [
+            ('debug', 'High - debug'),
+            ('verbose', 'Default - verbose'),
+            ('warning', 'Low - warning'),
+        ]
+
+        for level in logging_levels:
+            self.log_level_combo.append(level[0], level[1])
+
+        self._reset_combo()
+        content_area = self.get_content_area()
+
+        content_area.add(sub_title)
+        content_area.add(self.log_level_combo)
+        content_area.show_all()
+
+    def _reset_combo(self):
+        self.log_level_combo.set_active_id(self.settings['data'] or 'verbose')
+
+    def _on_response(self, dialog, response):
+        if response != Gtk.ResponseType.APPLY:
+            self.hide()
+            self._reset_combo()
+            return
+
+        setting = self.settings['data']
+        active_id = self.log_level_combo.get_active_id()
+
+        if setting == active_id:
+            self.hide()
+            return
+
+        if active_id != 'debug':
+            self.hide()
+            self.emit('logging-changed', active_id)
+            return
+
+        def on_dialog_response(dialog, response):
+            if response == Gtk.ResponseType.YES:
+                self.hide()
+                self.emit('logging-changed', active_id)
+            dialog.destroy()
+
+        message = (_(
+            'The debug logging level is not '
+            'recommended unless you are actually debugging an issue, '
+            'as it generates very large logs.\n\nAre you sure you want to set logging to debug?',
+        ))
+
+        dialog = Gtk.MessageDialog(
+            parent=self.pithos_window.prefs_dlg,
+            flags=Gtk.DialogFlags.MODAL,
+            type=Gtk.MessageType.WARNING,
+            buttons=Gtk.ButtonsType.YES_NO,
+            text=_('Debug Logging Level'),
+            secondary_text=message,
+        )
+
+        dialog.connect('response', on_dialog_response)
+        dialog.show()

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -11,4 +11,5 @@ data/io.github.Pithos.desktop.in
 pithos/application.py
 pithos/pithos.py
 pithos/StationsPopover.py
+pithos/plugins/journald_logging.py
 


### PR DESCRIPTION
Users can now enable, disable and set the logging level of the journald logging in Pithos.

It's set to disabled by default like all plugins. I'm not sure if I want it defaulted to enabled?

Edit: It now defaults to enabled.