### PR TITLE
Catch Secret.Collection.for_alias_sync returning None

### DIFF
--- a/pithos/util.py
+++ b/pithos/util.py
@@ -44,6 +44,16 @@ def unlock_keyring():
         None,
     )
 
+    if default_collection is None:
+        logging.warning(
+            'Could not get the default Secret Collection.\n'
+            'Attempting to use the session Collection.'
+        )
+
+        global _current_collection
+        _current_collection = Secret.COLLECTION_SESSION
+        return
+
     if not default_collection.get_locked():
         logging.debug('The default keyring is unlocked.')
     else:


### PR DESCRIPTION
If Secret.Collection.for_alias_sync returns None try to use the session session Collection. If any further errors occur there are deeper problems. More than likely something is misconfigured or otherwise broken. 