### PR TITLE
Last fm integration improvements

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -13,4 +13,4 @@ pithos/pithos.py
 pithos/StationsPopover.py
 pithos/PreferencesPithosDialog.py
 pithos/plugins/journald_logging.py
-
+pithos/plugins/lastfm.py


### PR DESCRIPTION
Use a headerbar.

Better logging.

The auth dialog now pops up when the plugin is enabled but Pithos is not authorized with Last.fm.
The plugin is also disabled if the dialog is closed and Pithos is not authorized with Last.fm.
This is to avoid confusion as to if the plugin is actually really enabled.

Use pylast.LastFMNetwork preferably instead of pylast.get_lastfm_network.

Show a dialog that tells the user the account url that the Last.fm plugin is authorized for and lets them decide if they want to continue to use that account on a Pandora login change.
![screenshot from 2017-04-09 07-37-58](https://cloud.githubusercontent.com/assets/6667703/24869908/4b22839c-1dda-11e7-9ab8-ba4d6fd6f1ab.png)
![screenshot from 2017-04-10 10-38-27](https://cloud.githubusercontent.com/assets/6667703/24869852/24ed20ec-1dda-11e7-8432-590dcb6e7142.png)
![screenshot from 2017-04-10 10-38-08](https://cloud.githubusercontent.com/assets/6667703/24869882/398099da-1dda-11e7-9b3e-74e53de20143.png)



