### PR TITLE
Handle not being able to rename Thumbprint Radio

### DIFF
--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -444,7 +444,7 @@ class PithosWindow(Gtk.ApplicationWindow):
             # Update rating icons and background, and generic cover icon and background.
             self.render_cover_art.update_icons(style_context)
 
-    def worker_run(self, fn, args=(), callback=None, message=None, context='net'):
+    def worker_run(self, fn, args=(), callback=None, message=None, context='net', errorback=None):
         if context and message:
             self.statusbar.push(self.statusbar.get_context_id(context), message)
 
@@ -475,7 +475,9 @@ class PithosWindow(Gtk.ApplicationWindow):
             else:
                 logging.warning(e.traceback)
 
-        self.worker.send(fn, args, cb, eb)
+        err = errorback or eb
+
+        self.worker.send(fn, args, cb, err)
 
     def get_proxy(self):
         """ Get HTTP proxy, first trying preferences then system proxy """


### PR DESCRIPTION
Pandora does not permit users to rename the Thumbprint Radio Station. This handles that by catching the appropriate Pandora error and showing a dialog explaining that to the user and resetting the name back to the old name in the stations dialog. Fixes: https://github.com/pithos/pithos/issues/370 for the most part.
![screenshot from 2017-04-11 09-22-29](https://cloud.githubusercontent.com/assets/6667703/24914012/8c2c0610-1e98-11e7-943d-3eed7059f837.png)
