### PR TITLE
Fix-up clear statusbar after rename error

### DIFF
--- a/pithos/StationsDialog.py
+++ b/pithos/StationsDialog.py
@@ -95,6 +95,7 @@ class StationsDialog(Gtk.Dialog):
         old_station_name = station.name
 
         def errorback(e):
+            self.pithos.statusbar.pop(self.pithos.statusbar.get_context_id('net'))
             if hasattr(e, 'status') and e.status == 1008 and old_station_name == 'Thumbprint Radio':
                 dialog = Gtk.MessageDialog(
                     parent=self,


### PR DESCRIPTION
Make sure to clear the statusbar after a rename error.

Oops. Didn't notice that the statusbar was stuck saying "Renaming Station..." This should clear it out after an error.