### PR TITLE
Disable keybinder in wayland

### DIFF
--- a/pithos/plugins/mediakeys.py
+++ b/pithos/plugins/mediakeys.py
@@ -25,125 +25,139 @@ class MediaKeyPlugin(PithosPlugin):
     preference = 'enable_mediakeys'
     description = 'Control playback with media keys'
 
-    def bind_dbus(self):
-        # FIXME: Make all dbus usage async
-        def grab_media_keys():
-            try:
-                self.mediakeys.call_sync(
-                    'GrabMediaPlayerKeys',
-                    GLib.Variant('(su)', (APP_ID, 0)),
-                    Gio.DBusCallFlags.NONE, -1, None,
-                )
+    method = None
 
-                return True
-            except GLib.Error as e:
-                logging.debug(e)
-                return False
+    def grab_media_keys(self):
+        try:
+            self.mediakeys.call_sync(
+                'GrabMediaPlayerKeys',
+                GLib.Variant('(su)', (APP_ID, 0)),
+                Gio.DBusCallFlags.NONE, -1, None,
+            )
 
-        bound = hasattr(self, 'method') and self.method == 'dbus' # We may have bound it earlier
-        if not bound:
-            try:
-                bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
-                logging.info('Got session bus')
-            except GLib.Error as e:
-                logging.warning(e)
-                return False
-
-            for de, bus_names in {
-                'gnome': ('org.gnome.SettingDaemon.MediaKeys', 'org.gnome.SettingsDaemon'),
-                'mate': ('org.mate.SettingsDaemon', )
-            }.items():
-                if not bound:
-                    for bus_name in bus_names:
-                        try:
-                            self.mediakeys = Gio.DBusProxy.new_sync(
-                                bus,
-                                Gio.DBusProxyFlags.DO_NOT_LOAD_PROPERTIES,
-                                None,
-                                bus_name,
-                                '/org/{}/SettingsDaemon/MediaKeys'.format(de),
-                                'org.{}.SettingsDaemon.MediaKeys'.format(de),
-                                None,
-                            )
-                            if grab_media_keys():
-                                bound = True
-                                break
-                        except GLib.Error as e:
-                            logging.warning(e)
-
-        if not bound:
+            return True
+        except GLib.Error as e:
+            logging.debug(e)
             return False
 
-        def update_focus_time(widget, event, userdata=None):
-            if event.changed_mask & Gdk.WindowState.FOCUSED and \
-               event.new_window_state & Gdk.WindowState.FOCUSED:
-                grab_media_keys()
-            return False
+    def release_media_keys(self):
+        try:
+            self.mediakeys.call_sync(
+                'ReleaseMediaPlayerKeys',
+                GLib.Variant('(s)', (APP_ID,)),
+                Gio.DBusCallFlags.NONE, -1, None,
+            )
 
-        def mediakey_signal(proxy, sender, signal, param, userdata=None):
-            if signal != 'MediaPlayerKeyPressed':
-                return
+        except GLib.Error as e:
+            logging.debug(e)
 
-            app, action = param.unpack()
-            if app == APP_ID:
-                if action == 'Play':
-                    self.window.playpause_notify()
-                elif action == 'Next':
-                    self.window.next_song()
-                elif action == 'Stop':
-                    self.window.user_pause()
-                elif action == 'Previous':
-                    self.window.bring_to_top()
+    def update_focus_time(self, widget, event, userdata=None):
+        if event.changed_mask & Gdk.WindowState.FOCUSED and \
+           event.new_window_state & Gdk.WindowState.FOCUSED:
+            self.grab_media_keys()
 
-        self.focus_hook = self.window.connect('window-state-event', update_focus_time)
-        if not getattr(self, 'mediakey_hook', 0):
-            self.mediakey_hook = self.mediakeys.connect('g-signal', mediakey_signal)
-        else:
-            grab_media_keys() # Was disabled previously
-        logging.info("Bound media keys with DBUS {}".format(self.mediakeys.props.g_interface_name))
-        self.method = 'dbus'
-        return True
+    def mediakey_signal(self, proxy, sender, signal, param, userdata=None):
+        if signal != 'MediaPlayerKeyPressed':
+            return
 
-    def bind_keybinder(self):
-        if not hasattr(self, 'keybinder'):
+        app, action = param.unpack()
+        if app == APP_ID:
+            if action == 'Play':
+                self.window.playpause_notify()
+            elif action == 'Next':
+                self.window.next_song()
+            elif action == 'Stop':
+                self.window.user_pause()
+            elif action == 'Previous':
+                self.window.bring_to_top()
+
+    def on_prepare(self):
+        # TODO: support more desktops.
+        try:
+            bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+            logging.info('Got session bus')
+        except GLib.Error as e:
+            bus = None
+            logging.warning(e)
+
+        if bus:
+            schema = Gio.SettingsSchemaSource.get_default()
+            gnome = schema.lookup('org.gnome.settings-daemon.plugins.media-keys', True)
+            if gnome:
+                name = 'org.gnome.SettingsDaemon.MediaKeys'
+                path = '/org/gnome/SettingsDaemon/MediaKeys'
+                bus_names = [
+                    'org.gnome.SettingsDaemon',
+                    'org.gnome.SettingDaemon.MediaKeys',
+                ]
+            else:
+                mate = schema.lookup('org.mate.settings-daemon.plugins.media-keys', True)
+                if mate:
+                    name = 'org.mate.SettingsDaemon.MediaKeys'
+                    path = '/org/mate/SettingsDaemon/MediaKeys'
+                    bus_names = [
+                        'org.mate.SettingsDaemon',
+                    ]
+                else:
+                    bus_names = None
+
+            if bus_names:
+                for bus_name in bus_names:
+                    try:
+                        self.mediakeys = Gio.DBusProxy.new_sync(
+                            bus,
+                            Gio.DBusProxyFlags.DO_NOT_LOAD_PROPERTIES,
+                            None,
+                            bus_name,
+                            path,
+                            name,
+                            None,
+                        )
+
+                        if self.grab_media_keys():
+                            self.method = 'dbus'
+                            break
+                    except GLib.Error as e:
+                        logging.debug(e)
+
+        if self.method is None:
+            display = self.window.props.screen.get_display()
+            if not type(display).__name__.endswith('X11Display'):
+                return 'Keybinder requires X11'
             try:
                 import gi
                 gi.require_version('Keybinder', '3.0')
-                # Gdk needed for Keybinder
                 from gi.repository import Keybinder
                 self.keybinder = Keybinder
                 self.keybinder.init()
+                self.method = 'keybinder'
             except (ValueError, ImportError):
-                return False
-
-        ret = self.keybinder.bind('XF86AudioPlay', self.window.playpause, None)
-        if not ret:  # Presumably all bindings will fail
-            return False
-        self.keybinder.bind('XF86AudioStop', self.window.user_pause, None)
-        self.keybinder.bind('XF86AudioNext', self.window.next_song, None)
-        self.keybinder.bind('XF86AudioPrev', self.window.bring_to_top, None)
-
-        logging.info("Bound media keys with keybinder")
-        self.method = 'keybinder'
-        return True
+                return 'Keybinder not found'
 
     def on_enable(self):
-        self.loaded = self.bind_dbus() or self.bind_keybinder()
-        if not self.loaded:
-            logging.error("Could not bind media keys")
+        if self.method == 'dbus':
+            self.focus_hook = self.window.connect('window-state-event', self.update_focus_time)
+            self.mediakey_hook = self.mediakeys.connect('g-signal', self.mediakey_signal)
+            logging.info('Bound media keys with DBUS {}'.format(self.mediakeys.props.g_interface_name))
+        elif self.method == 'keybinder':
+            ret = self.keybinder.bind('XF86AudioPlay', self.window.playpause, None)
+            if not ret:  # Presumably all bindings will fail
+                logging.error('Failed to bind media keys with Keybinder')
+                return
+            self.keybinder.bind('XF86AudioStop', self.window.user_pause, None)
+            self.keybinder.bind('XF86AudioNext', self.window.next_song, None)
+            self.keybinder.bind('XF86AudioPrev', self.window.bring_to_top, None)
+            logging.info('Bound media keys with Keybinder')
 
     def on_disable(self):
-        if not self.loaded:
-            return
         if self.method == 'dbus':
-            self.mediakeys.call_sync('ReleaseMediaPlayerKeys', GLib.Variant('(s)', (APP_ID,)),
-                                     Gio.DBusCallFlags.NONE, -1, None)
             self.window.disconnect(self.focus_hook)
-            self.focus_hook = 0
-            logging.info("Disabled dbus mediakey bindings")
+            self.mediakeys.disconnect(self.mediakey_hook)
+            self.release_media_keys()
+            logging.info('Disabled dbus mediakey bindings')
         elif self.method == 'keybinder':
             self.keybinder.unbind('XF86AudioPlay')
             self.keybinder.unbind('XF86AudioStop')
             self.keybinder.unbind('XF86AudioNext')
             self.keybinder.unbind('XF86AudioPrev')
-            logging.info("Disabled keybinder mediakey bindings")
+            logging.info('Disabled keybinder mediakey bindings')


### PR DESCRIPTION
Effectively rewrote the mediakeys plugin to make it fail gracefully and make it easier to add support for more DE's. Fixes: https://github.com/pithos/pithos/issues/448 