### PR TITLE
Still More Buffer Improvements

### DIFF
--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -295,6 +295,7 @@ class PithosWindow(Gtk.ApplicationWindow):
         self._query_buffer = Gst.Query.new_buffering(Gst.Format.PERCENT)
 
         self.player = Gst.ElementFactory.make("playbin", "player")
+        self.player.set_property('buffer-duration', 3 * Gst.SECOND)
 
         bus = self.player.get_bus()
         bus.add_signal_watch()
@@ -704,6 +705,8 @@ class PithosWindow(Gtk.ApplicationWindow):
         os.environ['PULSE_PROP_media.artist'] = song.artist
         os.environ['PULSE_PROP_media.name'] = '{}: {}'.format(song.artist, song.title)
         os.environ['PULSE_PROP_media.filename'] = audioUrl
+        self.player.set_property('buffer-size', int(song.bitrate) * 375)
+        self.player.set_property('connection-speed', int(song.bitrate))
         self.player.set_property("uri", audioUrl)
         self._set_player_state(PseudoGst.BUFFERING)
         self.playcount += 1


### PR DESCRIPTION
***Forever chasing a well behaved buffer***
This will set the buffers in Gstreamer to 3 secs worth of audio. And set the connection-speed prop to the bitrate of the current song. The result is less buffer fluttering.