### PR TITLE
Detect the Thumbprint Radio Station

### DIFF
--- a/pithos/StationsDialog.py
+++ b/pithos/StationsDialog.py
@@ -46,7 +46,11 @@ class StationsDialog(Gtk.Dialog):
         self.searchDialog = None
 
         self.modelfilter = self.model.filter_new()
-        self.modelfilter.set_visible_func(lambda m, i, d: m.get_value(i, 0) and not m.get_value(i, 0).isQuickMix)
+
+        def visible_func(m, i, d):
+            return m.get_value(i, 0) and not (m.get_value(i, 0).isQuickMix or m.get_value(i, 0).isThumbprint)
+
+        self.modelfilter.set_visible_func(visible_func)
 
         self.modelsortable = Gtk.TreeModelSort.sort_new_with_model(self.modelfilter)
         """
@@ -95,14 +99,14 @@ class StationsDialog(Gtk.Dialog):
 
         def errorback(e):
             self.pithos.statusbar.pop(self.pithos.statusbar.get_context_id('net'))
-            if hasattr(e, 'status') and e.status == 1008 and old_station_name == 'Thumbprint Radio':
+            if hasattr(e, 'status') and e.status == 1008:
                 dialog = Gtk.MessageDialog(
                     parent=self,
                     flags=Gtk.DialogFlags.MODAL,
                     type=Gtk.MessageType.WARNING,
                     buttons=Gtk.ButtonsType.OK,
-                    text='Could Not Rename Thumbprint Radio',
-                    secondary_text='Pandora does not permit renaming the Thumbprint Radio Station.',
+                    text='Could Not Rename {}'.format(old_station_name),
+                    secondary_text='Pandora does not permit renaming {}.'.format(old_station_name),
                 )
 
                 dialog.connect('response', lambda *ignore: dialog.destroy())

--- a/pithos/StationsPopover.py
+++ b/pithos/StationsPopover.py
@@ -92,7 +92,7 @@ class StationsPopover(Gtk.Popover):
         self.listbox.invalidate_filter()
 
     def listbox_header(self, row, before):
-        if before and before.station.isQuickMix and not row.get_header():
+        if before and before.station.isThumbprint and not row.get_header():
             row.set_header(Gtk.Separator.new(Gtk.Orientation.HORIZONTAL))
         elif row.get_header():
             row.set_header(None)
@@ -110,7 +110,7 @@ class StationsPopover(Gtk.Popover):
         return False
 
     def listbox_sort(self, row1, row2):
-        if row1.station.isQuickMix: # Always first
+        if row1.station.isQuickMix or row1.station.isThumbprint: # Always first
             return -1
         if not self.sorted: # This is the order Pandora lists it (aka create date)
             if row1.index < row2.index:

--- a/pithos/pandora/pandora.py
+++ b/pithos/pandora/pandora.py
@@ -378,6 +378,7 @@ class Station:
         self.idToken = d['stationToken']
         self.isCreator = not d['isShared']
         self.isQuickMix = d['isQuickMix']
+        self.isThumbprint = d.get('isThumbprint', False)
         self.name = d['stationName']
         self.useQuickMix = False
 

--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -648,7 +648,11 @@ class PithosWindow(Gtk.ApplicationWindow):
         self.stations_popover.clear()
         self.current_station = None
         selected = None
-
+        # Make sure that the Thumprint Radio Station is always 2nd.
+        for i, s in enumerate(self.pandora.stations):
+            if s.isThumbprint:
+                self.pandora.stations.insert(1, self.pandora.stations.pop(i))
+                break
         for i, s in enumerate(self.pandora.stations):
             if s.isQuickMix and s.isCreator:
                 self.stations_model.append((s, "QuickMix", i))


### PR DESCRIPTION
This will make it so we treat the Thumbprint Radio similar to the QuickMix. It will always be right after the QuickMix in the stations popover and will not show up in the station dialog since it can't be renamed. It will also always be the 2nd station in MPRIS.