### PR TITLE
First steps in making plugins GObjects

### DIFF
--- a/pithos/PreferencesPithosDialog.py
+++ b/pithos/PreferencesPithosDialog.py
@@ -51,7 +51,8 @@ class PithosPluginRow(Gtk.ListBoxRow):
         self.switch.connect('notify::active', self.on_activated)
         self.switch.set_valign(Gtk.Align.CENTER)
         box.pack_end(self.switch, False, False, 2)
-        self.connect('grab-focus', self.on_grab_focus)
+        self.connect('grab-focus', self.set_prefs_btn)
+        self.plugin.connect('notify::enabled', self.on_enabled)
 
         if plugin.prepared and plugin.error:
             self.set_sensitive(False)
@@ -59,7 +60,11 @@ class PithosPluginRow(Gtk.ListBoxRow):
 
         self.add(box)
 
-    def set_prefs_btn(self):
+    def on_enabled(self, *ignore):
+        if self.is_selected():
+            self.set_prefs_btn()
+
+    def set_prefs_btn(self, *ignore):
         prefs_btn = self.get_toplevel().preference_btn
         if self.plugin.enabled:
             sensitive = self.plugin.preferences_dialog is not None
@@ -71,9 +76,6 @@ class PithosPluginRow(Gtk.ListBoxRow):
         else:
             tooltip = _('This plugin either must be enabled or does not support preferences.')
         prefs_btn.set_tooltip_text(tooltip)
-
-    def on_grab_focus(self, *ignore):
-        self.set_prefs_btn()
 
     def on_activated(self, obj, params):
         if not self.is_selected():

--- a/pithos/plugin.py
+++ b/pithos/plugin.py
@@ -18,23 +18,35 @@ import glob
 import os
 from gi.repository import (
     GLib,
-    Gio
+    Gio,
+    GObject
 )
 
 
-class PithosPlugin:
+class PithosPlugin(GObject.Object):
+    __gtype_name__ = 'PithosPlugin'
+
     _PITHOS_PLUGIN = True # used to find the plugin class in a module
     preference = None
     description = ""
 
     def __init__(self, name, window, bus):
+        super().__init__()
         self.name = name
         self.window = window
         self.bus = bus
         self.preferences_dialog = None
         self.prepared = False
-        self.enabled = False
+        self._enabled = False
         self.error = None
+
+    @GObject.Property
+    def enabled(self):
+        return self._enabled
+
+    @enabled.setter
+    def enabled(self, enabled):
+        self._enabled = enabled
 
     def enable(self):
         if not self.prepared:


### PR DESCRIPTION
This is the 1st step in making plugins GObjects. This allows us to potentially to do a bunch of neat stuff. For now this particular commit fixes a bug where when enabling a plugin with a prefs window the prefs button is not sensitive until you click off somewhere else and back on that plugin. This was caused because our plugins now load async.