### PR TITLE
Don't GoTo songs that are banned or tired.

### DIFF
--- a/pithos/plugins/mpris.py
+++ b/pithos/plugins/mpris.py
@@ -755,7 +755,7 @@ class PithosMprisService(DBusServiceObject):
     def GoTo(self, TrackId):
         '''(o) -> nothing Interface MediaPlayer2.TrackList'''
         song = self._song_from_track_id(TrackId)
-        if song and song.index > self.window.current_song_index:
+        if song and song.index > self.window.current_song_index and not (song.tired or song.rating == 'ban'):
             self.window.start_song(song.index)
 
     @dbus_method(MEDIA_PLAYER2_RATINGS_IFACE, in_signature='o')


### PR DESCRIPTION
A user shouldn't be able to GoTo a song that is banned or tired because Pithos will just skip that banned or tired song and play the next song. In the case the song is banned or tired it makes more sense to do nothing. It's more of an expected behaviour then playing a song that wasn't selected(the next song).