### PR TITLE
We don't have to lie about being able to seek any longer

### DIFF
--- a/pithos/plugins/mpris.py
+++ b/pithos/plugins/mpris.py
@@ -606,9 +606,7 @@ class PithosMprisService(DBusServiceObject):
     @dbus_property(MEDIA_PLAYER2_PLAYER_IFACE, signature='b')
     def CanSeek(self):
         '''b Read only Interface MediaPlayer2.Player'''
-        # This a lie because some sound applets depend upon
-        # this to show song position/duration info
-        return True
+        return False
 
     @dbus_property(MEDIA_PLAYER2_PLAYER_IFACE, signature='b')
     def CanControl(self):
@@ -699,7 +697,7 @@ class PithosMprisService(DBusServiceObject):
     @dbus_method(MEDIA_PLAYER2_PLAYER_IFACE, in_signature='x')
     def Seek(self, Offset):
         '''Not Implemented'''
-        self.Seeked(self.Position)
+        pass
 
     @dbus_method(MEDIA_PLAYER2_PLAYER_IFACE, in_signature='s')
     def OpenUri(self, Uri):
@@ -708,28 +706,8 @@ class PithosMprisService(DBusServiceObject):
 
     @dbus_method(MEDIA_PLAYER2_PLAYER_IFACE, in_signature='ox')
     def SetPosition(self, TrackId, Position):
-        '''
-        We can't actually seek, we lie so gnome-shell-extensions-mediaplayer[1] will show the
-        position slider. We send a Seeked signal with the current position to make sure applets
-        update their postion.
-
-        Under normal circumstances SetPosition would tell the player where to seek to and any
-        seeking caused by either the MPRIS client or the player would cause a Seeked signal to
-        be fired with current track position after the seek.
-
-        (The MPRIS client tells the player that it wants to seek to a position >>>
-         the player seeks to the disired position >>>
-         the player tells the MPRIS client were it actually seeked too.)
-
-        We're skipping the middleman(Pithos) because we can't seek. Some players do not send
-        a Seeked signal and some clients workaround that[2] so this may not be necessary for
-        all clients.
-
-        [1] https://github.com/eonpatapon/gnome-shell-extensions-mediaplayer/issues/246
-        [2] https://github.com/eonpatapon/gnome-shell-extensions-mediaplayer#known-bugs
-        '''
-
-        self.Seeked(self.Position)
+        '''Not Implemented'''
+        pass
 
     @dbus_method(MEDIA_PLAYER2_PLAYLISTS_IFACE, in_signature='uusb', out_signature='a(oss)')
     def GetPlaylists(self, Index, MaxCount, Order, ReverseOrder):


### PR DESCRIPTION
The visibility of the position slider in https://github.com/JasonLG1979/gnome-shell-extensions-mediaplayer was decoupled from the CanSeek prop a while ago. As long as a Player provides a length in the metadata and can provide a valid postion the slider is visible. CanSeek determines if the slider is reactive. For Pithos that means the slider is visible but can't be moved by the user.