### PR TITLE
Use a HeaderBar in the main Pithos Window

### DIFF
--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -244,6 +244,12 @@ class PithosWindow(Gtk.ApplicationWindow):
     def __init__(self, app, test_mode):
         super().__init__(application=app)
         self.init_template()
+        self.headerbar = Gtk.HeaderBar.new()
+        self.set_titlebar(self.headerbar)
+        self.headerbar.set_show_close_button(True)
+        self.headerbar.set_has_subtitle(False)
+        self.headerbar.show()
+        self.set_title('Pithos')
 
         self.settings = Gio.Settings.new('io.github.Pithos')
         self.settings.connect('changed::audio-quality', self.set_audio_quality)


### PR DESCRIPTION
A small change that gets rid of the weird "Pithos" menu on DE's other than GNOME Shell. In a future redesign we might actually put our own widgets in the headerbar.

Here's basically what it would look like on most other DE's besides GNOME Shell:

![screenshot from 2017-09-03 09-16-02](https://user-images.githubusercontent.com/6667703/30003830-a1863540-9089-11e7-97a0-ade5c57d9af3.png)
