### PR TITLE
Raise the priority of the GLib.idle_add's in the worker to GLib.PRIORITY_DEFAULT

### DIFF
--- a/pithos/gobject_worker.py
+++ b/pithos/gobject_worker.py
@@ -26,11 +26,11 @@ class GObjectWorker:
             try:
                 result = command(*args)
                 if callback:
-                    GLib.idle_add(callback, result)
+                    GLib.idle_add(callback, result, priority=GLib.PRIORITY_DEFAULT)
             except Exception as e:
                 e.traceback = traceback.format_exc()
                 if errorback:
-                    GLib.idle_add(errorback, e)
+                    GLib.idle_add(errorback, e, priority=GLib.PRIORITY_DEFAULT)
         if errorback is None:
             errorback = self._default_errorback
         data = command, args, callback, errorback


### PR DESCRIPTION
As it sits now the entry priority of worker threads is really low. Worker threads have to wait for time to refresh in the UI for example because it's a higher priority.

This commit has the effect of making things that use the worker thread generally more "snappy". Songs load faster in the UI, station searches are faster, song ratings are faster.