### PR TITLE
Remember the windows size and if it's maximized

### DIFF
--- a/data/io.github.Pithos.gschema.xml
+++ b/data/io.github.Pithos.gschema.xml
@@ -47,6 +47,16 @@
       <summary>Position of window</summary>
     </key>
 
+    <key type="(ii)" name="win-size">
+      <default>(500,360)</default>
+      <summary>Size of window</summary>
+    </key>
+
+    <key type="b" name="win-maxed">
+      <default>false</default>
+      <summary>If the window is maximized</summary>
+    </key>
+
     <key type="d" name="volume">
       <default>0.7</default>
       <range min="0.0" max="1.0"/>

--- a/data/ui/PithosWindow.ui
+++ b/data/ui/PithosWindow.ui
@@ -14,6 +14,7 @@
     <property name="default_height">360</property>
     <property name="icon_name">io.github.Pithos</property>
     <signal name="configure-event" handler="on_configure_event" swapped="no"/>
+    <signal name="window-state-event" handler="on_window_state_event" swapped="no"/>
     <signal name="destroy" handler="on_destroy" swapped="no"/>
     <child>
       <object class="GtkBox" id="vbox1">


### PR DESCRIPTION
This also debounces the window configure events as to not hammer the settings and takes into acount that getting the windows position in Wayland is not possible.