### PR TITLE
Further simplifiy/improve the notifiy plugin

### DIFF
--- a/pithos/application.py
+++ b/pithos/application.py
@@ -88,12 +88,9 @@ class PithosApplication(Gtk.Application):
         action.connect("activate", lambda action, param: self.window.next_song())
         self.add_action(action)
 
-        action = Gio.SimpleAction.new("play", None)
-        action.connect("activate", lambda action, param: self.window.user_play())
-        self.add_action(action)
-
-        action = Gio.SimpleAction.new("pause", None)
-        action.connect("activate", lambda action, param: self.window.user_pause())
+        # Needed for notifications to function as expected in KDE.
+        action = Gio.SimpleAction.new("activate", None)
+        action.connect("activate", lambda action, param: self.activate())
         self.add_action(action)
 
         if Gtk.get_major_version() > 3 or Gtk.get_minor_version() >= 20:


### PR DESCRIPTION
Remove unused logging import
Don't keep track of notification id's
Add a fallback icon

Works fine on GNOME. Getting ready to test this on XFCE, KDE, MATE, Cinnamon and Pantheon and will makes further tweaks if needed.