### PR TITLE
Put album art in a directory that is cleaned up even if Pithos is killed

### DIFF
--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -366,8 +366,7 @@ class PithosWindow(Gtk.ApplicationWindow):
         self.worker = GObjectWorker()
 
         try:
-            self.tempdir = tempfile.TemporaryDirectory(prefix='pithos-',
-                                                       dir=GLib.get_user_cache_dir())
+            self.tempdir = tempfile.TemporaryDirectory(prefix='pithos-')
             logging.info("Created temporary directory %s" %self.tempdir.name)
         except IOError as e:
             self.tempdir = None


### PR DESCRIPTION
Today I found that over the course of 1 year and 9 months I have accumulated 213 pithos temp directories in ~/.cache, totalling 365 MiB. There doesn't seem to be any advantage to putting album art in ~/.cache instead of /tmp, and there is a significant disadvantage because files in ~/.cache are not automatically deleted if Pithos is not properly closed.