### PR TITLE
Changed name of method from SupportedUriScheme to SupportedUriSchemes to

### DIFF
--- a/pithos/plugins/mpris.py
+++ b/pithos/plugins/mpris.py
@@ -495,7 +495,7 @@ class PithosMprisService(DBusServiceObject):
         return 'io.github.Pithos'
 
     @dbus_property(MEDIA_PLAYER2_IFACE, signature='as')
-    def SupportedUriScheme(self):
+    def SupportedUriSchemes(self):
         '''as Read only Interface MediaPlayer2'''
         return []
 


### PR DESCRIPTION
Changed name of method from SupportedUriScheme to SupportedUriSchemes to
conform to the spec at:
https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Property:SupportedUriSchemes

This fixes integration with KDE's Media Player framework

Addresses Issue: Media Keys Will Not Bind in KDE (even with Keybinder) #595