### PR TITLE
WIP: Show non-modal infobar for some errors

### DIFF
--- a/data/ui/PithosWindow.ui
+++ b/data/ui/PithosWindow.ui
@@ -234,6 +234,39 @@
           </object>
         </child>
         <child>
+          <object class="GtkInfoBar" id="error_infobar">
+            <property name="visible">1</property>
+            <property name="message-type">warning</property>
+            <property name="revealed">0</property>
+            <child internal-child="content_area">
+              <object class="GtkBox">
+                <property name="visible">1</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child internal-child="action_area">
+              <object class="GtkBox">
+                <property name="visible">1</property>
+                <child>
+                  <object class="GtkButton" id="info_button_retry">
+                    <property name="label" translatable="yes">Retry</property>
+                    <property name="visible">1</property>
+                    <property name="can_default">1</property>
+                    <property name="receives_default">1</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <action-widgets>
+              <action-widget response="0">info_button_retry</action-widget>
+            </action-widgets>
+          </object>
+        </child>
+        <child>
           <object class="GtkScrolledWindow">
             <property name="visible">1</property>
             <property name="vadjustment">adjustment</property>
@@ -255,7 +288,6 @@
           </object>
           <packing>
             <property name="expand">1</property>
-            <property name="position">1</property>
           </packing>
         </child>
         <child>
@@ -263,9 +295,6 @@
             <property name="visible">1</property>
             <property name="spacing">2</property>
           </object>
-          <packing>
-            <property name="position">2</property>
-          </packing>
         </child>
       </object>
     </child>

--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -248,6 +248,7 @@ class PithosWindow(Gtk.ApplicationWindow):
     api_update_dialog_real = GtkTemplate.Child()
     error_dialog_real = GtkTemplate.Child()
     fatal_error_dialog_real = GtkTemplate.Child()
+    error_infobar = GtkTemplate.Child()
 
     def __init__(self, app, test_mode):
         super().__init__(application=app)
@@ -504,7 +505,7 @@ class PithosWindow(Gtk.ApplicationWindow):
             elif isinstance(e, PandoraAPIVersionError):
                 self.api_update_dialog()
             elif isinstance(e, PandoraError):
-                self.error_dialog(e.message, retry_cb, submsg=e.submsg)
+                self.info_bar(e.message, retry_cb, submsg=e.submsg)
             else:
                 logging.warning(e.traceback)
 
@@ -939,6 +940,26 @@ class PithosWindow(Gtk.ApplicationWindow):
 
         self.waiting_for_playlist = True
         self.worker_run(self.current_station.get_playlist, (), callback, "Getting songs...")
+
+    def info_bar(self, message, retry_cb, submsg=None):
+        content = self.error_infobar.get_content_area()
+        label = content.get_children()[0]
+        markup = '<b>{}</b>'.format(html.escape(message))
+        if submsg:
+            markup += ': {}'.format(html.escape(submsg))
+        label.set_markup(markup)
+
+        response_handler = 0
+
+        def on_response(infobar, response, *ignore):
+            infobar.props.revealed = False
+            infobar.disconnect(response_handler)
+            if response == 0:
+                retry_cb()
+
+        response_handler = self.error_infobar.connect('response', on_response)
+        self.error_infobar.props.revealed = True
+
 
     def error_dialog(self, message, retry_cb, submsg=None):
         dialog = self.error_dialog_real


### PR DESCRIPTION
TODO:
- [ ] Since this is no longer modal we need to hide the infobar when the error is bypassed. I guess we effectively need to track a "connected" state.
- [ ] We may want to retry automatically in some situations
- [ ] We can show better buttons, like on auth failure show preferences not retry
- [ ] Some pandora errors deserve the dialog?
- [ ] Ellipsize long messages, and add tooltip for full message?

The pandora error messages frankly suck, maybe we should add our own, bit out of scope for this PR...

See also #611