### PR TITLE
Adding in an activate handler for search box - resolves #597

### DIFF
--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -416,7 +416,7 @@ class PithosWindow(Gtk.ApplicationWindow):
         self.stations_popover.set_model(self.stations_model)
         self.stations_popover.listbox.connect('row-activated', self.active_station_changed)
         self.stations_button.set_popover(self.stations_popover)
-        self.stations_popover.search.connect('activate',self.search_activate_handler)
+        self.stations_popover.search.connect('activate', self.search_activate_handler)
 
     def init_actions(self, app):
         action = Gio.SimpleAction.new('playpause', None)
@@ -1254,10 +1254,9 @@ class PithosWindow(Gtk.ApplicationWindow):
     def search_activate_handler(self,station):
         row = self.stations_popover.listbox.get_row_at_y(0)
         if not row:
-            return False
-        self.active_station_changed(self.stations_popover.listbox,row)
-        self.stations_popover.hide()
-        self.stations_popover.search.set_text('')
+            return
+        self.station_changed(row.station)
+        self.stations_popover.on_row_activated(self.stations_popover.listbox, row)
 
     def active_station_changed(self, listbox, row):
         self.station_changed(row.station)

--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -416,6 +416,7 @@ class PithosWindow(Gtk.ApplicationWindow):
         self.stations_popover.set_model(self.stations_model)
         self.stations_popover.listbox.connect('row-activated', self.active_station_changed)
         self.stations_button.set_popover(self.stations_popover)
+        self.stations_popover.search.connect('activate',self.search_activate_handler)
 
     def init_actions(self, app):
         action = Gio.SimpleAction.new('playpause', None)
@@ -1249,6 +1250,14 @@ class PithosWindow(Gtk.ApplicationWindow):
         if self.ui_loop_timer_id:
             GLib.source_remove(self.ui_loop_timer_id)
             self.ui_loop_timer_id = 0
+
+    def search_activate_handler(self,station):
+        row = self.stations_popover.listbox.get_row_at_y(0)
+        if not row:
+            return False
+        self.active_station_changed(self.stations_popover.listbox,row)
+        self.stations_popover.hide()
+        self.stations_popover.search.set_text('')
 
     def active_station_changed(self, listbox, row):
         self.station_changed(row.station)


### PR DESCRIPTION
The purpose of this PR is to allow users to accept the first search result when filtering stations with the Enter key instead of having to click on the result.