### PR TITLE
Add flatpak manifest to repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "flatpak/shared-modules"]
+	path = flatpak/shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/flatpak/io.github.Pithos.json
+++ b/flatpak/io.github.Pithos.json
@@ -1,0 +1,46 @@
+{
+  "app-id": "io.github.Pithos",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "master",
+  "sdk": "org.gnome.Sdk",
+  "command": "pithos",
+  "finish-args": [
+    "--share=ipc",
+    "--share=network",
+    "--socket=fallback-x11",
+    "--socket=x11",
+    "--socket=wayland",
+    "--socket=pulseaudio",
+    "--metadata=X-DConf=migrate-path=/io/github/Pithos/",
+    "--talk-name=org.freedesktop.secrets",
+    "--talk-name=org.gnome.SettingsDaemon.MediaKeys",
+    "--talk-name=org.mate.SettingsDaemon",
+    "--talk-name=org.kde.StatusNotifierWatcher"
+  ],
+  "modules": [
+    "shared-modules/dbus-glib/dbus-glib-0.110.json",
+    "shared-modules/libappindicator/libappindicator-gtk3-introspection-12.10.json",
+    "python3-pylast.json",
+    {
+      "name": "keybinder",
+      "cleanup": ["/lib/*.la", "/include", "/share", "/lib/pkgconfig"],
+      "sources": [{
+        "type": "archive",
+        "url": "https://github.com/kupferlauncher/keybinder/releases/download/keybinder-3.0-v0.3.2/keybinder-3.0-0.3.2.tar.gz",
+        "sha256": "e6e3de4e1f3b201814a956ab8f16dfc8a262db1937ff1eee4d855365398c6020"
+      }]
+    },
+    {
+      "name": "pithos",
+      "builddir": true,
+      "buildsystem": "meson",
+      "cleanup": ["/share/man"],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/pithos/pithos.git"
+        }
+      ]
+    }
+  ]
+}

--- a/flatpak/python3-pylast.json
+++ b/flatpak/python3-pylast.json
@@ -1,0 +1,19 @@
+{
+    "name": "python3-pylast",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} pylast"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/16/d8/bc6316cf98419719bd59c91742194c111b6f2e85abac88e496adefaf7afe/six-1.11.0.tar.gz",
+            "sha256": "70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/8a/1a/ece4ef4ebf51236ac25e9708fb3e1e70b6447e01262f8b156ccbda894fa9/pylast-2.2.0.tar.gz",
+            "sha256": "a21a10e559cbb80db5eb72e20a22740496a292977ed3568c937560b8d6885ab4"
+        }
+    ]
+}


### PR DESCRIPTION
This allows for easy one-click building in GNOME
Builder. This makes it much easier for new developers
to contribute, and much easier for designers to test.

Based on https://github.com/flathub/io.github.Pithos/