### PR TITLE
ui: Make fit on small (mobile) screens

### DIFF
--- a/data/ui/PithosWindow.ui
+++ b/data/ui/PithosWindow.ui
@@ -53,180 +53,160 @@
         <property name="visible">1</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkToolbar">
+          <object class="GtkBox">
             <property name="visible">1</property>
-            <property name="show_arrow">0</property>
-            <property name="icon_size">2</property>
+            <property name="can_focus">False</property>
+            <property name="spacing">6</property>
+            <property name="margin_start">6</property>
+            <property name="margin_end">6</property>
+            <property name="margin_top">6</property>
+            <property name="margin_bottom">6</property>
             <child>
-              <object class="GtkToolItem">
+              <object class="GtkBox" id="playcontrol_box">
                 <property name="visible">1</property>
+                <property name="homogeneous">1</property>
+                <child internal-child="accessible">
+                  <object class="AtkObject" id="playcontrol_box-atkobject">
+                    <property name="AtkObject::accessible-description" translatable="yes">playback controls</property>
+                  </object>
+                </child>
                 <child>
-                  <object class="GtkBox" id="playcontrol_box">
+                  <object class="GtkButton" id="playpause_button">
                     <property name="visible">1</property>
-                    <property name="homogeneous">1</property>
+                    <property name="can_focus">1</property>
+                    <property name="action_name">win.playpause</property>
                     <child internal-child="accessible">
-                      <object class="AtkObject" id="playcontrol_box-atkobject">
-                        <property name="AtkObject::accessible-description" translatable="yes">playback controls</property>
+                      <object class="AtkObject" id="playpause_button-atkobject">
+                        <property name="AtkObject::accessible-description" translatable="yes">play/pause</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkButton" id="playpause_button">
+                      <object class="GtkImage" id="playpause_image">
                         <property name="visible">1</property>
-                        <property name="can_focus">1</property>
-                        <property name="action_name">win.playpause</property>
-                        <child internal-child="accessible">
-                          <object class="AtkObject" id="playpause_button-atkobject">
-                            <property name="AtkObject::accessible-description" translatable="yes">play/pause</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkImage" id="playpause_image">
-                            <property name="visible">1</property>
-                            <property name="icon_name">media-playback-start-symbolic</property>
-                            <property name="icon_size">2</property>
-                          </object>
-                        </child>
+                        <property name="icon_name">media-playback-start-symbolic</property>
+                        <property name="icon_size">2</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkButton">
+                    <property name="visible">1</property>
+                    <property name="can_focus">1</property>
+                    <property name="action_name">win.skip</property>
+                    <child internal-child="accessible">
+                      <object class="AtkObject" id="skip_button-atkobject">
+                        <property name="AtkObject::accessible-description" translatable="yes">skip</property>
                       </object>
                     </child>
                     <child>
+                      <object class="GtkImage" id="skip_image">
+                        <property name="visible">1</property>
+                        <property name="icon_name">media-skip-forward-symbolic</property>
+                        <property name="icon_size">2</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkVolumeButton" id="volume">
+                    <property name="visible">1</property>
+                    <property name="can_focus">1</property>
+                    <property name="relief">none</property>
+                    <property name="focus_on_click">0</property>
+                    <property name="orientation">vertical</property>
+                    <signal name="value-changed" handler="on_volume_change_event" swapped="no"/>
+                    <child internal-child="accessible">
+                      <object class="AtkObject" id="volume-atkobject">
+                        <property name="AtkObject::accessible-description" translatable="yes">volume</property>
+                      </object>
+                    </child>
+                    <child internal-child="plus_button">
                       <object class="GtkButton">
-                        <property name="visible">1</property>
                         <property name="can_focus">1</property>
-                        <property name="action_name">win.skip</property>
-                        <child internal-child="accessible">
-                          <object class="AtkObject" id="skip_button-atkobject">
-                            <property name="AtkObject::accessible-description" translatable="yes">skip</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkImage" id="skip_image">
-                            <property name="visible">1</property>
-                            <property name="icon_name">media-skip-forward-symbolic</property>
-                            <property name="icon_size">2</property>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkVolumeButton" id="volume">
-                        <property name="visible">1</property>
-                        <property name="can_focus">1</property>
+                        <property name="receives_default">1</property>
+                        <property name="halign">center</property>
+                        <property name="valign">center</property>
                         <property name="relief">none</property>
-                        <property name="focus_on_click">0</property>
-                        <property name="orientation">vertical</property>
-                        <signal name="value-changed" handler="on_volume_change_event" swapped="no"/>
-                        <child internal-child="accessible">
-                          <object class="AtkObject" id="volume-atkobject">
-                            <property name="AtkObject::accessible-description" translatable="yes">volume</property>
-                          </object>
-                        </child>
-                        <child internal-child="plus_button">
-                          <object class="GtkButton">
-                            <property name="can_focus">1</property>
-                            <property name="receives_default">1</property>
-                            <property name="halign">center</property>
-                            <property name="valign">center</property>
-                            <property name="relief">none</property>
-                          </object>
-                        </child>
-                        <child internal-child="minus_button">
-                          <object class="GtkButton">
-                            <property name="can_focus">1</property>
-                            <property name="receives_default">1</property>
-                            <property name="halign">center</property>
-                            <property name="valign">center</property>
-                            <property name="relief">none</property>
-                          </object>
-                        </child>
                       </object>
-                      <packing>
-                        <property name="position">2</property>
-                      </packing>
                     </child>
-                    <style>
-                      <class name="linked"/>
-                    </style>
+                    <child internal-child="minus_button">
+                      <object class="GtkButton">
+                        <property name="can_focus">1</property>
+                        <property name="receives_default">1</property>
+                        <property name="halign">center</property>
+                        <property name="valign">center</property>
+                        <property name="relief">none</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <style>
+                  <class name="linked"/>
+                </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkMenuButton" id="stations_button">
+                <property name="visible">1</property>
+                <property name="can_focus">1</property>
+                <property name="halign">end</property>
+                <property name="hexpand">True</property>
+                <child internal-child="accessible">
+                  <object class="AtkObject" id="stations_button-atkobject">
+                    <property name="AtkObject::accessible-description" translatable="yes">stations</property>
                   </object>
                 </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkSeparatorToolItem">
-                <property name="visible">1</property>
-                <property name="draw">0</property>
-              </object>
-              <packing>
-                <property name="expand">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkToolItem">
-                <property name="visible">1</property>
-                <property name="width-request">300</property>
                 <child>
-                  <object class="GtkMenuButton" id="stations_button">
+                  <object class="GtkBox">
                     <property name="visible">1</property>
-                    <property name="can_focus">1</property>
-                    <property name="halign">end</property>
-                    <child internal-child="accessible">
-                      <object class="AtkObject" id="stations_button-atkobject">
-                        <property name="AtkObject::accessible-description" translatable="yes">stations</property>
-                      </object>
-                    </child>
+                    <property name="spacing">5</property>
                     <child>
-                      <object class="GtkBox">
+                      <object class="GtkLabel" id="stations_label">
                         <property name="visible">1</property>
-                        <property name="spacing">5</property>
-                        <child>
-                          <object class="GtkLabel" id="stations_label">
-                            <property name="visible">1</property>
-                            <property name="single_line_mode">1</property>
-                            <property name="ellipsize">end</property>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkImage">
-                            <property name="visible">1</property>
-                            <property name="halign">end</property>
-                            <property name="valign">center</property>
-                            <property name="icon_name">pan-down-symbolic</property>
-                            <property name="icon_size">1</property>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkToolItem">
-                <property name="visible">1</property>
-                <child>
-                  <object class="GtkMenuButton">
-                    <property name="visible">1</property>
-                    <property name="can_focus">1</property>
-                    <property name="use-popover">TRUE</property>
-                    <property name="menu-model">app-menu</property>
-                    <property name="halign">end</property>
-                    <child internal-child="accessible">
-                      <object class="AtkObject">
-                        <property name="AtkObject::accessible-description" translatable="yes">menu</property>
+                        <property name="single_line_mode">1</property>
+                        <property name="ellipsize">end</property>
                       </object>
                     </child>
                     <child>
                       <object class="GtkImage">
                         <property name="visible">1</property>
-                        <property name="icon_name">open-menu-symbolic</property>
+                        <property name="halign">end</property>
+                        <property name="valign">center</property>
+                        <property name="icon_name">pan-down-symbolic</property>
                         <property name="icon_size">1</property>
                       </object>
+                      <packing>
+                        <property name="position">1</property>
+                      </packing>
                     </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkMenuButton">
+                <property name="visible">1</property>
+                <property name="can_focus">1</property>
+                <property name="use-popover">TRUE</property>
+                <property name="menu-model">app-menu</property>
+                <property name="halign">end</property>
+                <child internal-child="accessible">
+                  <object class="AtkObject">
+                    <property name="AtkObject::accessible-description" translatable="yes">menu</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkImage">
+                    <property name="visible">1</property>
+                    <property name="icon_name">open-menu-symbolic</property>
+                    <property name="icon_size">1</property>
                   </object>
                 </child>
               </object>

--- a/data/ui/PreferencesPithosDialog.ui
+++ b/data/ui/PreferencesPithosDialog.ui
@@ -3,7 +3,6 @@
 <interface>
   <requires lib="gtk+" version="3.14"/>
   <template class="PreferencesPithosDialog" parent="GtkDialog">
-    <property name="width_request">400</property>
     <property name="title" translatable="yes">Preferences</property>
     <property name="resizable">False</property>
     <property name="modal">1</property>
@@ -24,6 +23,7 @@
     </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
+        <property name="width_request">360</property>
         <property name="visible">1</property>
         <child>
           <object class="GtkNotebook" id="notebook1">

--- a/data/ui/SearchDialog.ui
+++ b/data/ui/SearchDialog.ui
@@ -3,9 +3,6 @@
 <interface>
   <requires lib="gtk+" version="3.14"/>
   <template class="SearchDialog" parent="GtkDialog">
-    <property name="width_request">380</property>
-    <property name="height_request">350</property>
-    <property name="resizable">0</property>
     <property name="border_width">2</property>
     <property name="modal">1</property>
     <property name="title" translatable="yes">Search</property>
@@ -25,6 +22,8 @@
       <object class="GtkBox" id="dialog-vbox1">
         <property name="visible">1</property>
         <property name="spacing">2</property>
+        <!-- 360 - 4 due to border-width == 2-->
+        <property name="width_request">356</property>
         <child>
           <object class="GtkVBox" id="vbox1">
             <property name="visible">1</property>

--- a/data/ui/StationsDialog.ui
+++ b/data/ui/StationsDialog.ui
@@ -3,8 +3,6 @@
 <interface>
   <requires lib="gtk+" version="3.14"/>
   <template class="StationsDialog" parent="GtkDialog">
-    <property name="width_request">480</property>
-    <property name="height_request">420</property>
     <property name="modal">1</property>
     <signal name="delete-event" handler="on_close" swapped="no"/>
     <child internal-child="vbox">
@@ -33,6 +31,7 @@
         <property name="visible">1</property>
         <property name="title" translatable="yes">Manage Stations</property>
         <property name="show_close_button">1</property>
+        <property name="width_request">360</property>
         <child>
           <object class="GtkButton" id="button1">
             <property name="visible">1</property>


### PR DESCRIPTION
Adjust width requests and widgets to fit on mobile screens. 
Removes the toolbar in favor of a GtkBox, as the toolbar
prevented proper sizing and is removed in GTK4.