### PR TITLE
Increase default size of main window

### DIFF
--- a/data/ui/PithosWindow.ui
+++ b/data/ui/PithosWindow.ui
@@ -43,8 +43,8 @@
   </object>
   <template class="PithosWindow" parent="GtkApplicationWindow">
     <property name="title" translatable="yes">Pithos</property>
-    <property name="default_width">500</property>
-    <property name="default_height">360</property>
+    <property name="default_width">550</property>
+    <property name="default_height">430</property>
     <property name="icon_name">io.github.Pithos</property>
     <signal name="configure-event" handler="on_configure_event" swapped="no"/>
     <signal name="destroy" handler="on_destroy" swapped="no"/>


### PR DESCRIPTION
Increasing the default window size makes the headerbar look a little less cramped and allows for 4 tracks to be shown without being cut off. It's purely subjective and cosmetic.