### PR TITLE
Adding in shortcut key for stations popover

### DIFF
--- a/pithos/StationsPopover.py
+++ b/pithos/StationsPopover.py
@@ -140,6 +140,11 @@ class StationsPopover(Gtk.Popover):
         for row in self.listbox.get_children():
             row.destroy()
 
+    def make_visible(self,*ignore):
+        if self.props.visible:
+            self.hide()
+        else:
+            self.show_all()
     def set_model(self, model):
         model.connect('row-inserted', self.insert_row)
         model.connect('row-changed', self.change_row)

--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -474,6 +474,10 @@ class PithosWindow(Gtk.ApplicationWindow):
         app.add_accelerator('<Primary>d', 'win.bookmark', None)
         action.connect('activate', self.bookmark_song)
 
+        action = Gio.SimpleAction.new('station-popover', None)
+        self.add_action(action)
+        app.add_accelerator('<Primary>r', 'win.station-popover', None)
+        action.connect('activate', self.stations_popover.make_visible)
     def worker_run(self, fn, args=(), callback=None, message=None, context='net', errorback=None, user_data=None):
         if context and message:
             self.statusbar.push(self.statusbar.get_context_id(context), message)


### PR DESCRIPTION
This PR sets Cntrl-R to toggle the stations popover to make keyboard navigation easier as requested in Issue #648 .