### PR TITLE
Do not fail if locale attributes are not present

### DIFF
--- a/bin/pithos.in
+++ b/bin/pithos.in
@@ -38,7 +38,6 @@ try:
     locale.textdomain('pithos')
 except AttributeError:
     print("Could not bind to locale translation domain.  Some translations won't work")
-    pass
 gettext.install('pithos', localedir)
 
 resource = Gio.resource_load(os.path.join(pkgdatadir, 'pithos.gresource'))

--- a/bin/pithos.in
+++ b/bin/pithos.in
@@ -33,8 +33,12 @@ if builddir:
     theme.append_search_path(os.path.join(pkgdatadir, 'icons'))
 
 sys.path.insert(1, srcdir)
-locale.bindtextdomain('pithos', localedir)
-locale.textdomain('pithos')
+try:
+    locale.bindtextdomain('pithos', localedir)
+    locale.textdomain('pithos')
+except AttributeError:
+    print("Could not bind to locale translation domain.  Some translations won't work")
+    pass
 gettext.install('pithos', localedir)
 
 resource = Gio.resource_load(os.path.join(pkgdatadir, 'pithos.gresource'))


### PR DESCRIPTION
I've been trying to package Pithos for Alpine Linux (actually really for PostmarketOS).  So far the only issue I've had running Pithos on my Pinephone is that Alpine doesn't seem to have python locale support.  So translations won't work but IMO it is better than nothing.

This just causes us to catch the AttributeError and allows the application to continue running with a warning.

Updated with a branch to master. 