### PR TITLE
fix: delete temp files on exit 

### DIFF
--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -1076,7 +1076,6 @@ class PithosWindow(Gtk.ApplicationWindow):
         self.current_song.duration = self.query_duration() or self.current_song.trackLength * Gst.SECOND
         self.current_song.duration_message = self.format_time(self.current_song.duration)
         self.update_song_row()
-        self.check_if_song_is_ad()
         # We can't seek so duration in MPRIS is just for display purposes if it's not off by more than a sec it's OK.
         if self.current_song.get_duration_sec() != self.current_song.trackLength:
             self.emit('metadata-changed', self.current_song)
@@ -1114,20 +1113,6 @@ class PithosWindow(Gtk.ApplicationWindow):
 
         if not GstPbutils.install_plugins_installation_in_progress():
             self.next_song()
-
-    def check_if_song_is_ad(self):
-        if self.current_song.is_ad is None:
-            if self.current_song.duration:
-                if self.current_song.get_duration_sec() < 45:  # Less than 45 seconds we assume it's an ad
-                    logging.info('Ad detected!')
-                    self.current_song.is_ad = True
-                    self.update_song_row()
-                    self.set_title("Commercial Advertisement - Pithos")
-                else:
-                    logging.info('Not an Ad..')
-                    self.current_song.is_ad = False
-            else:
-                logging.warning('dur_stat is False. The assumption that duration is available once the stream-start messages feeds is bad.')
 
     def on_gst_buffering(self, bus, message):
         # React to the buffer message immediately and also fire a short repeating timeout

--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -369,7 +369,7 @@ class PithosWindow(Gtk.ApplicationWindow):
             if is_flatpak():
                 # However in flatpak that path is not readable by the host.
                 tempdir_base = os.path.join(GLib.get_user_cache_dir(), 'tmp')
-            self.tempdir = tempfile.TemporaryDirectory(prefix='pithos-', dir=tempdir_base)
+            self.tempdir = tempfile.TemporaryDirectory(prefix='pithos-', dir=tempdir_base, ignore_cleanup_errors=True)
             logging.info("Created temporary directory {}".format(self.tempdir.name))
         except IOError as e:
             self.tempdir = None


### PR DESCRIPTION
I added the `ignore_cleanup_errors=True` flag to make sure the `tempfile` library stayed honest and actually deleted the directories it created.  This prevents the buildup of directories and files and closes issue #686.

If you want to actually use this as a cache I would remove the `tempfile` library and opt for a simpler system for file governance.  You explicitly set `tempdir_base` without it anyway, and there seems to be no other reliance on it elsewhere.

Is actual caching a feature you/others want? Any other meta-data that should be cached?