### PR TITLE
Avoid racecondition when buffering that appears to halt Pithos

### DIFF
--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -1204,7 +1204,15 @@ class PithosWindow(Gtk.ApplicationWindow):
         album = html.escape(song.album)
         msg = []
         if song is self.current_song:
-            song.position = self.query_position()
+            # Avoid race condition where query_position() sometimes points us
+            # permanently to an invalid segment if we are called whilst
+            # buffering. Most reliable semaphore for buffering state is
+            # buffering_timer_id, cleared after buffering (see on_gst_buffering())
+            if self.buffering_timer_id == 0:
+                song.position = self.query_position()
+            else:
+                song.position = None
+
             if not song.bitrate is None:
                 msg.append("%skbit/s" % (song.bitrate))
 


### PR DESCRIPTION
Displaying the remaining song time in the GUI is triggered from a per-second timer. If the position in the stream is queried exactly at the time a buffering refresh is finishing, Pithos sometimes ends up permanently pointing somewhere that doesn't answer queries or alert to an end-of-song. On a congested network, this means Pithos appears to stop playing every song or two.

This fix is the barest minimum change, that avoids making the query to determine the stream position when we are in a buffering situation.

Fixes [#679](https://github.com/pithos/pithos/issues/679)