### PR TITLE
Migrate to playbin3

### DIFF
--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -300,7 +300,7 @@ class PithosWindow(Gtk.ApplicationWindow):
         self._query_position = Gst.Query.new_position(Gst.Format.TIME)
         self._query_buffer = Gst.Query.new_buffering(Gst.Format.PERCENT)
 
-        self.player = Gst.ElementFactory.make("playbin", "player")
+        self.player = Gst.ElementFactory.make("playbin3", "play")
         self.player.set_property('buffer-duration', 3 * Gst.SECOND)
         self.rgvolume = Gst.ElementFactory.make("rgvolume", "rgvolume")
         self.rgvolume.set_property("album-mode", False)

--- a/pithos/pithos.py
+++ b/pithos/pithos.py
@@ -300,7 +300,7 @@ class PithosWindow(Gtk.ApplicationWindow):
         self._query_position = Gst.Query.new_position(Gst.Format.TIME)
         self._query_buffer = Gst.Query.new_buffering(Gst.Format.PERCENT)
 
-        self.player = Gst.ElementFactory.make("playbin3", "play")
+        self.player = Gst.ElementFactory.make("playbin3", "player")
         self.player.set_property('buffer-duration', 3 * Gst.SECOND)
         self.rgvolume = Gst.ElementFactory.make("rgvolume", "rgvolume")
         self.rgvolume.set_property("album-mode", False)


### PR DESCRIPTION
Pithos currently plays the audio stream using the _gstPlayer_ object  from _playbin_
The _gstPlayer_ library is deprecated since GStreamer 1.20 and Gstreamer release notes state they plan to remove it altogether in 1.24.

_gstPlay_ (from _playbin3_) is the GStreamer recommended replacement, which is a drop-in replacement for audio streams.

Upgrading Pithos to use _gstPlay_ also does not appear to exhibit the race condition between querying the stream position and buffering that causes Pithos to appear to stop every few songs on a congested network, observed since gstreamer 1.20.

This change is a simple migration from _gstPlayer_ to _gstPlay_, that also happens to fix  #679